### PR TITLE
TLS support and minor changes

### DIFF
--- a/MQTTClient/form.json
+++ b/MQTTClient/form.json
@@ -6,11 +6,18 @@
 		{ "name": "TLS", "type": "CheckBox", "caption": "TLS" },
 		{ "name": "PingInterval", "type": "NumberSpinner", "caption": "Ping Interval" },
 		{ "type": "Select", "name": "ModuleType", "caption": "Modul Type",
-    "options": [
-        { "label": "Script", "value": 1 },
-        { "label": "Forward", "value": 2 }
-    ]
-	},
+			"options": [
+				{ "label": "Script", "value": 1 },
+				{ "label": "Forward", "value": 2 }
+			]
+		},
+		{ "type": "Select", "name": "MQTTVersion", "caption": "MQTT Version",
+			"options": [
+				{ "label": "3.1", "value": 1 },
+				{ "label": "3.1.1", "value": 2 }
+			]
+		},
+		{ "name": "AutoSubscribe", "type": "CheckBox", "caption": "Auto Subscribe Topic # on connect" },
         { "name": "ClientID", "type": "ValidationTextBox", "caption": "MQTT ClientID" },
         { "name": "script", "type": "SelectScript", "caption": "Handle Script" }
 	]

--- a/MQTTClient/form.json
+++ b/MQTTClient/form.json
@@ -3,6 +3,8 @@
 	[
 		{ "name": "User", "type": "ValidationTextBox", "caption": "Username" },
 		{ "name": "Password", "type": "PasswordTextBox", "caption": "Password" },
+		{ "name": "TLS", "type": "CheckBox", "caption": "TLS" },
+		{ "name": "PingInterval", "type": "NumberSpinner", "caption": "Ping Interval" },
 		{ "type": "Select", "name": "ModuleType", "caption": "Modul Type",
     "options": [
         { "label": "Script", "value": 1 },

--- a/MQTTClient/locale.json
+++ b/MQTTClient/locale.json
@@ -7,7 +7,11 @@
         "Script": "Script",
         "Forward": "Weiterleitung (Forward)",
         "MQTT ClientID": "MQTT ClientID",
-        "Handle Script": "Handle Script"
+        "Handle Script": "Handle Script",
+        "TLS": "TLS",
+        "Ping Interval": "Ping Intervall",
+        "Auto Subscribe Topic # on connect": "Nach Verbindungsaufbau automatisch # abonnieren",
+        "MQTT Version": "MQTT Version"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -56,6 +56,57 @@ Es werden alle Nachrichten in das Log von IP-Symcon geschrieben.
 | TX | {97475B04-67C3-A74D-C970-E9409B0EFA1D}  |
 | RX | {DBDA9DF7-5D04-F49D-370A-2B9153D00D9B}  |
 
+#### Auto Subscribe #
+
+Wenn der Modul Typ Forward aktiviert ist, kann über die Konfigurationsoption "Nach Verbindungsaufbau automatisch # abonnieren" automatisch das Topic # abonniert werden.
+Dies stellt im wesentlichen die Rückwärtskompatibilität zu älteren Modulen her.
+
+#### Subscribe durch Modul
+
+Um von einem Child Modul eine Subscription auszulösen kann vom Child Modul folgendender Befehl an den Parent (MQTTClient) gesendet werden:
+```php
+    $cmd = json_encode([
+        'Function'  => 'Subscribe',
+        'Topic'     => 'topic/to/subsribe'
+    ]);
+    $json = json_encode([
+        'DataID'    => '{97475B04-67C3-A74D-C970-E9409B0EFA1D}',
+        'Buffer'    => utf8_encode($cmd)
+    ]);
+    parent::SendDataToParent($json);
+```
+
+um zu publishen kann folgender Code verweendet werden:
+```php
+    $cmd = json_encode([
+        'Function'  => 'Publish',
+        'Topic'     => 'topic/to/publish',
+        'Payload'   => 'Payload',
+        'Retain'    => 0
+    ]);
+    $json = json_encode([
+        'DataID'    => '{97475B04-67C3-A74D-C970-E9409B0EFA1D}',
+        'Buffer'    => utf8_encode($cmd)
+    ]);
+    parent::SendDataToParent($json);
+```
+
+Fehlt die Angabe der "Function" so wird wie in alten Versionen ein Publish gesendet.
+
+### 4.3 TLS
+
+Durch aktivieren der TLS Option wird nach dem Verbindungsaufbau ein TLS Handshake durchgeführt. Dies basiert auf der PTLS Library (Copyright (c) 2016 Ryohei Nagatsuka) welches dem [HomeConnectSymcon](https://github.com/hermanthegerman2/HomeConnectSymcon) Modul entnommen ist.
+
+### 4.4 Ping Intervall
+
+Ist das Ping Intervall > 0 wird alle X Sekunden ein MQTT PINGREQ gesendet
+
+### 4.5 MQTT Version
+
+Das zugrunde liegende phpMQTT Modul beherrscht nur die MQTT Version 3.1 - dies wurde um die Version 3.1.1 erweitert. Über die Konfiguration kann man auswählen welche Version genutzt werden soll (beim Handshake).
+
+Die Erweiterung auf 3.1.1 wurde nicht intensiv getestet, funktioniert aber für die Basisfunktionen Subscribe und Publish augenscheinlich zuverlässig (die Protokollunterschiede scheinen auch marginal zu sein).
+
 ## 5 Funktionen
 
 **MQTTC_Publish(string $Topic, string $payload, $qos, $retain)**

--- a/libs/TFphpMQTT.php
+++ b/libs/TFphpMQTT.php
@@ -48,6 +48,9 @@ declare(strict_types=1);
 /* phpMQTT */
 class phpMQTT
 {
+    public const MQTT_VERSION_31 = 1;
+    public const MQTT_VERSION_311 = 2;
+
     public $keepalive = 30;		/* default keepalive timmer */
     public $topics = []; 	/* used to store currently subscribed topics */
     public $clientid;			/* client id sent to brocker, string */
@@ -77,7 +80,7 @@ class phpMQTT
 
     /* connects to the broker
         inputs: $clean: should the client send a clean session flag */
-    public function connect($clean = true, $will = null, $username = null, $password = null)
+    public function connect($clean = true, $will = null, $username = null, $password = null, $version = phpMQTT::MQTT_VERSION_311)
     {
         $this->status = 1;
 
@@ -96,19 +99,42 @@ class phpMQTT
 
         $buffer .= chr(0x00);
         $i++;
-        $buffer .= chr(0x04);
-        $i++;
-        $buffer .= chr(0x4d);
-        $i++;   // M
-        $buffer .= chr(0x51);
-        $i++;   // Q
-        $buffer .= chr(0x54);
-        $i++;   // T
-        $buffer .= chr(0x54);
-        $i++;   // T
-        $buffer .= chr(0x04);
-        $i++;   // Version
+        switch($version){
+            case phpMQTT::MQTT_VERSION_31:
+                $buffer .= chr(0x06);
+                $i++;
+                $buffer .= chr(0x4d);
+                $i++;   // M
+                $buffer .= chr(0x51);
+                $i++;   // Q
+                $buffer .= chr(0x49);
+                $i++;   // I
+                $buffer .= chr(0x73);
+                $i++;   // s
+                $buffer .= chr(0x64);
+                $i++;   // d
+                $buffer .= chr(0x70);
+                $i++;   // p
+                $buffer .= chr(0x03);
+                $i++;   // Version
+                break;
 
+            default:
+                $buffer .= chr(0x04);
+                $i++;
+                $buffer .= chr(0x4d);
+                $i++;   // M
+                $buffer .= chr(0x51);
+                $i++;   // Q
+                $buffer .= chr(0x54);
+                $i++;   // T
+                $buffer .= chr(0x54);
+                $i++;   // T
+                $buffer .= chr(0x04);
+                $i++;   // Version
+                break;
+        }
+        
         //No Will
         $var = 0;
         if ($clean) {
@@ -300,7 +326,7 @@ class phpMQTT
         $buffer .= chr($qos);
         $i++;
 
-        $cmd = 0x80;  // => 'subscribe'
+        $cmd = 0x82;  // => 'subscribe'
         //$qos
         $cmd += ($qos << 1);
 

--- a/libs/TLS/AESGCM/AESGCM.php
+++ b/libs/TLS/AESGCM/AESGCM.php
@@ -1,0 +1,491 @@
+<?php
+
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Spomky-Labs
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+namespace AESGCM;
+
+use Assert\Assertion;
+
+final class AESGCM
+{
+    /**
+     * @param string $K Key encryption key
+     * @param string $IV Initialization vector
+     * @param null|string $P Data to encrypt (null for authentication)
+     * @param null|string $A Additional Authentication Data
+     * @param int $tag_length Tag length
+     *
+     * @return array
+     */
+    public static function encrypt($K, $IV, $P = null, $A = null, $tag_length = 128)
+    {
+        Assertion::string($K, 'The key encryption key must be a binary string.');
+        $key_length = mb_strlen($K, '8bit') * 8;
+        Assertion::inArray($key_length, [128, 192, 256], 'Bad key encryption key length.');
+        Assertion::string($IV, 'The Initialization Vector must be a binary string.');
+        Assertion::nullOrString($P, 'The data to encrypt must be null or a binary string.');
+        Assertion::nullOrString($A, 'The Additional Authentication Data must be null or a binary string.');
+        Assertion::integer($tag_length, 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
+        Assertion::inArray($tag_length, [128, 120, 112, 104, 96], 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
+
+        if (version_compare(PHP_VERSION, '7.1.0RC5') >= 0 && null !== $P) {
+            return self::encryptWithPHP71($K, $key_length, $IV, $P, $A, $tag_length);
+        } elseif (class_exists('\Crypto\Cipher')) {
+            return self::encryptWithCryptoExtension($K, $key_length, $IV, $P, $A, $tag_length);
+        }
+
+        return self::encryptWithPHP($K, $key_length, $IV, $P, $A, $tag_length);
+    }
+
+    /**
+     * This method will append the tag at the end of the ciphertext.
+     *
+     * @param string $K Key encryption key
+     * @param string $IV Initialization vector
+     * @param null|string $P Data to encrypt (null for authentication)
+     * @param null|string $A Additional Authentication Data
+     * @param int $tag_length Tag length
+     *
+     * @return string
+     */
+    public static function encryptAndAppendTag($K, $IV, $P = null, $A = null, $tag_length = 128)
+    {
+        return implode(self::encrypt($K, $IV, $P, $A, $tag_length));
+    }
+
+    /**
+     * @param string $K Key encryption key
+     * @param string $key_length Key length
+     * @param string $IV Initialization vector
+     * @param null|string $P Data to encrypt (null for authentication)
+     * @param null|string $A Additional Authentication Data
+     * @param int $tag_length Tag length
+     *
+     * @return array
+     */
+    private static function encryptWithPHP71($K, $key_length, $IV, $P = null, $A = null, $tag_length = 128)
+    {
+        $mode = 'aes-' . ($key_length) . '-gcm';
+        $T = null;
+        $C = openssl_encrypt($P, $mode, $K, OPENSSL_RAW_DATA, $IV, $T, $A, $tag_length / 8);
+        Assertion::true(false !== $C, 'Unable to encrypt the data.');
+
+        return [$C, $T];
+    }
+
+    /**
+     * @param string $K Key encryption key
+     * @param string $key_length Key length
+     * @param string $IV Initialization vector
+     * @param null|string $P Data to encrypt (null for authentication)
+     * @param null|string $A Additional Authentication Data
+     * @param int $tag_length Tag length
+     *
+     * @return array
+     */
+    private static function encryptWithPHP($K, $key_length, $IV, $P = null, $A = null, $tag_length = 128)
+    {
+        list($J0, $v, $a_len_padding, $H) = self::common($K, $key_length, $IV, $A);
+
+        $C = self::getGCTR($K, $key_length, self::getInc(32, $J0), $P);
+        $u = self::calcVector($C);
+        $c_len_padding = self::addPadding($C);
+
+        $S = self::getHash($H, $A . str_pad('', $v / 8, "\0") . $C . str_pad('', $u / 8, "\0") . $a_len_padding . $c_len_padding);
+        $T = self::getMSB($tag_length, self::getGCTR($K, $key_length, $J0, $S));
+
+        return [$C, $T];
+    }
+
+    /**
+     * @param string $K Key encryption key
+     * @param string $key_length Key length
+     * @param string $IV Initialization vector
+     * @param null|string $P Data to encrypt (null for authentication)
+     * @param null|string $A Additional Authentication Data
+     * @param int $tag_length Tag length
+     *
+     * @return array
+     */
+    private static function encryptWithCryptoExtension($K, $key_length, $IV, $P = null, $A = null, $tag_length = 128)
+    {
+        $cipher = \Crypto\Cipher::aes(\Crypto\Cipher::MODE_GCM, $key_length);
+        $cipher->setAAD($A);
+        $cipher->setTagLength($tag_length / 8);
+        $C = $cipher->encrypt($P, $K, $IV);
+        $T = $cipher->getTag();
+
+        return [$C, $T];
+    }
+
+    /**
+     * @param string $K Key encryption key
+     * @param string $IV Initialization vector
+     * @param string|null $C Data to encrypt (null for authentication)
+     * @param string|null $A Additional Authentication Data
+     * @param string $T Tag
+     *
+     * @return string
+     */
+    public static function decrypt($K, $IV, $C, $A, $T)
+    {
+        Assertion::string($K, 'The key encryption key must be a binary string.');
+        $key_length = mb_strlen($K, '8bit') * 8;
+        Assertion::inArray($key_length, [128, 192, 256], 'Bad key encryption key length.');
+        Assertion::string($IV, 'The Initialization Vector must be a binary string.');
+        Assertion::nullOrString($C, 'The data to encrypt must be null or a binary string.');
+        Assertion::nullOrString($A, 'The Additional Authentication Data must be null or a binary string.');
+
+        $tag_length = self::getLength($T);
+        Assertion::integer($tag_length, 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
+        Assertion::inArray($tag_length, [128, 120, 112, 104, 96], 'Invalid tag length. Supported values are: 128, 120, 112, 104 and 96.');
+
+        if (version_compare(PHP_VERSION, '7.1.0RC5') >= 0 && null !== $C) {
+            return self::decryptWithPHP71($K, $key_length, $IV, $C, $A, $T);
+        } elseif (class_exists('\Crypto\Cipher')) {
+            return self::decryptWithCryptoExtension($K, $key_length, $IV, $C, $A, $T, $tag_length);
+        }
+
+        return self::decryptWithPHP($K, $key_length, $IV, $C, $A, $T, $tag_length);
+    }
+
+    /**
+     * This method should be used if the tag is appended at the end of the ciphertext.
+     * It is used by some AES GCM implementations such as the Java one.
+     *
+     * @param string $K Key encryption key
+     * @param string $IV Initialization vector
+     * @param string|null $Ciphertext Data to encrypt (null for authentication)
+     * @param string|null $A Additional Authentication Data
+     * @param int $tag_length Tag length
+     *
+     * @return string
+     *
+     * @see self::encryptAndAppendTag
+     */
+    public static function decryptWithAppendedTag($K, $IV, $Ciphertext = null, $A = null, $tag_length = 128)
+    {
+        $tag_length_in_bits = $tag_length / 8;
+        $C = mb_substr($Ciphertext, 0, -$tag_length_in_bits, '8bit');
+        $T = mb_substr($Ciphertext, -$tag_length_in_bits, null, '8bit');
+
+        return self::decrypt($K, $IV, $C, $A, $T);
+    }
+
+    /**
+     * @param string $K Key encryption key
+     * @param string $key_length Key length
+     * @param string $IV Initialization vector
+     * @param string|null $C Data to encrypt (null for authentication)
+     * @param string|null $A Additional Authentication Data
+     * @param string $T Tag
+     *
+     * @return string
+     */
+    private static function decryptWithPHP71($K, $key_length, $IV, $C, $A, $T)
+    {
+        $mode = 'aes-' . ($key_length) . '-gcm';
+        $P = openssl_decrypt(null === $C ? '' : $C, $mode, $K, OPENSSL_RAW_DATA, $IV, $T, $A);
+        Assertion::true(false !== $P, 'Unable to decrypt or to verify the tag.');
+
+        return $P;
+    }
+
+    /**
+     * @param string $K Key encryption key
+     * @param string $key_length Key length
+     * @param string $IV Initialization vector
+     * @param string|null $C Data to encrypt (null for authentication)
+     * @param string|null $A Additional Authentication Data
+     * @param string $T Tag
+     * @param int $tag_length Tag length
+     *
+     * @return string
+     */
+    private static function decryptWithPHP($K, $key_length, $IV, $C, $A, $T, $tag_length = 128)
+    {
+        list($J0, $v, $a_len_padding, $H) = self::common($K, $key_length, $IV, $A);
+
+        $P = self::getGCTR($K, $key_length, self::getInc(32, $J0), $C);
+
+        $u = self::calcVector($C);
+        $c_len_padding = self::addPadding($C);
+
+        $S = self::getHash($H, $A . str_pad('', $v / 8, "\0") . $C . str_pad('', $u / 8, "\0") . $a_len_padding . $c_len_padding);
+        $T1 = self::getMSB($tag_length, self::getGCTR($K, $key_length, $J0, $S));
+        Assertion::eq($T1, $T, 'Unable to decrypt or to verify the tag.');
+
+        return $P;
+    }
+
+    /**
+     * @param string $K Key encryption key
+     * @param string $key_length Key length
+     * @param string $IV Initialization vector
+     * @param string|null $C Data to encrypt (null for authentication)
+     * @param string|null $A Additional Authentication Data
+     * @param string $T Tag
+     * @param int $tag_length Tag length
+     *
+     * @return string
+     */
+    private static function decryptWithCryptoExtension($K, $key_length, $IV, $C, $A, $T, $tag_length = 128)
+    {
+        $cipher = \Crypto\Cipher::aes(\Crypto\Cipher::MODE_GCM, $key_length);
+        $cipher->setTag($T);
+        $cipher->setAAD($A);
+        $cipher->setTagLength($tag_length / 8);
+
+        return $cipher->decrypt($C, $K, $IV);
+    }
+
+    /**
+     * @param $K
+     * @param $key_length
+     * @param $IV
+     * @param $A
+     *
+     * @return array
+     */
+    private static function common($K, $key_length, $IV, $A)
+    {
+        $H = openssl_encrypt(str_repeat("\0", 16), 'aes-' . ($key_length) . '-ecb', $K, OPENSSL_NO_PADDING | OPENSSL_RAW_DATA); //---
+        $iv_len = self::getLength($IV);
+
+        if (96 === $iv_len) {
+            $J0 = $IV . pack('H*', '00000001');
+        } else {
+            $s = self::calcVector($IV);
+            Assertion::eq(($s + 64) % 8, 0, 'Unable to decrypt or to verify the tag.');
+
+            $packed_iv_len = pack('N', $iv_len);
+            $iv_len_padding = str_pad($packed_iv_len, 8, "\0", STR_PAD_LEFT);
+            $hash_X = $IV . str_pad('', ($s + 64) / 8, "\0") . $iv_len_padding;
+            $J0 = self::getHash($H, $hash_X);
+        }
+        $v = self::calcVector($A);
+        $a_len_padding = self::addPadding($A);
+
+        return [$J0, $v, $a_len_padding, $H];
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return int
+     */
+    private static function calcVector($value)
+    {
+        return (128 * ceil(self::getLength($value) / 128)) - self::getLength($value);
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return string
+     */
+    private static function addPadding($value)
+    {
+        return str_pad(pack('N', self::getLength($value)), 8, "\0", STR_PAD_LEFT);
+    }
+
+    /**
+     * @param string $x
+     *
+     * @return int
+     */
+    private static function getLength($x)
+    {
+        return mb_strlen($x, '8bit') * 8;
+    }
+
+    /**
+     * @param int $num_bits
+     * @param int $x
+     *
+     * @return string
+     */
+    private static function getMSB($num_bits, $x)
+    {
+        $num_bytes = $num_bits / 8;
+
+        return mb_substr($x, 0, $num_bytes, '8bit');
+    }
+
+    /**
+     * @param int $num_bits
+     * @param int $x
+     *
+     * @return string
+     */
+    private static function getLSB($num_bits, $x)
+    {
+        $num_bytes = ($num_bits / 8);
+
+        return mb_substr($x, -$num_bytes, null, '8bit');
+    }
+
+    /**
+     * @param int $s_bits
+     * @param int $x
+     *
+     * @return string
+     */
+    private static function getInc($s_bits, $x)
+    {
+        $lsb = self::getLSB($s_bits, $x);
+        $X = self::toUInt32Bits($lsb) + 1;
+        $res = self::getMSB(self::getLength($x) - $s_bits, $x) . pack('N', $X);
+
+        return $res;
+    }
+
+    /**
+     * @param string $bin
+     *
+     * @return mixed
+     */
+    private static function toUInt32Bits($bin)
+    {
+        list(, $h, $l) = unpack('n*', $bin);
+
+        return $l + ($h * 0x010000);
+    }
+
+    /**
+     * @param $X
+     * @param $Y
+     *
+     * @return string
+     */
+    private static function getProduct($X, $Y)
+    {
+        $R = pack('H*', 'E1') . str_pad('', 15, "\0");
+        $Z = str_pad('', 16, "\0");
+        $V = $Y;
+
+        $parts = str_split($X, 4);
+        $x = sprintf('%032b%032b%032b%032b', self::toUInt32Bits($parts[0]), self::toUInt32Bits($parts[1]), self::toUInt32Bits($parts[2]), self::toUInt32Bits($parts[3]));
+        $lsb_mask = "\1";
+        for ($i = 0; $i < 128; $i++) {
+            if ($x[$i]) {
+                $Z = self::getBitXor($Z, $V);
+            }
+            $lsb_8 = mb_substr($V, -1, null, '8bit');
+            if (ord($lsb_8 & $lsb_mask)) {
+                $V = self::getBitXor(self::shiftStringToRight($V), $R);
+            } else {
+                $V = self::shiftStringToRight($V);
+            }
+        }
+
+        return $Z;
+    }
+
+    /**
+     * @param string $input
+     *
+     * @return string
+     */
+    private static function shiftStringToRight($input)
+    {
+        $width = 4;
+        $parts = array_map('self::toUInt32Bits', str_split($input, $width));
+        $runs = count($parts);
+
+        for ($i = $runs - 1; $i >= 0; $i--) {
+            if ($i) {
+                $lsb1 = $parts[$i - 1] & 0x00000001;
+                if ($lsb1) {
+                    $parts[$i] = ($parts[$i] >> 1) | 0x80000000;
+                    $parts[$i] = pack('N', $parts[$i]);
+                    continue;
+                }
+            }
+            $parts[$i] = ($parts[$i] >> 1) & 0x7FFFFFFF;
+            $parts[$i] = pack('N', $parts[$i]);
+        }
+        $res = implode('', $parts);
+
+        return $res;
+    }
+
+    /**
+     * @param string $H
+     * @param string $X
+     *
+     * @return mixed
+     */
+    private static function getHash($H, $X)
+    {
+        $Y = [];
+        $Y[0] = str_pad('', 16, "\0");
+        $num_blocks = (int)(mb_strlen($X, '8bit') / 16);
+        for ($i = 1; $i <= $num_blocks; $i++) {
+            $Y[$i] = self::getProduct(self::getBitXor($Y[$i - 1], mb_substr($X, ($i - 1) * 16, 16, '8bit')), $H);
+        }
+
+        return $Y[$num_blocks];
+    }
+
+    /**
+     * @param string $K
+     * @param int $key_length
+     * @param string $ICB
+     * @param string $X
+     *
+     * @return string
+     */
+    private static function getGCTR($K, $key_length, $ICB, $X)
+    {
+        if (empty($X)) {
+            return '';
+        }
+
+        $n = (int)ceil(self::getLength($X) / 128);
+        $CB = [];
+        $Y = [];
+        $CB[1] = $ICB;
+        for ($i = 2; $i <= $n; $i++) {
+            $CB[$i] = self::getInc(32, $CB[$i - 1]);
+        }
+        $mode = 'aes-' . ($key_length) . '-ecb';
+        for ($i = 1; $i < $n; $i++) {
+            $C = openssl_encrypt($CB[$i], $mode, $K, OPENSSL_NO_PADDING | OPENSSL_RAW_DATA);
+            $Y[$i] = self::getBitXor(mb_substr($X, ($i - 1) * 16, 16, '8bit'), $C);
+        }
+
+        $Xn = mb_substr($X, ($n - 1) * 16, null, '8bit');
+        $C = openssl_encrypt($CB[$n], $mode, $K, OPENSSL_NO_PADDING | OPENSSL_RAW_DATA);
+        $Y[$n] = self::getBitXor($Xn, self::getMSB(self::getLength($Xn), $C));
+
+        return implode('', $Y);
+    }
+
+    /**
+     * @param string $o1
+     * @param string $o2
+     *
+     * @return string
+     */
+    private static function getBitXor($o1, $o2)
+    {
+        $xorWidth = PHP_INT_SIZE;
+        $o1 = str_split($o1, $xorWidth);
+        $o2 = str_split($o2, $xorWidth);
+        $res = '';
+        $runs = count($o1);
+        for ($i = 0; $i < $runs; $i++) {
+            $res .= $o1[$i] ^ $o2[$i];
+        }
+
+        return $res;
+    }
+}

--- a/libs/TLS/AESGCM/LICENSE
+++ b/libs/TLS/AESGCM/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Spomky-Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs/TLS/Assert/Assert.php
+++ b/libs/TLS/Assert/Assert.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Assert
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace Assert;
+
+/**
+ * AssertionChain factory.
+ */
+abstract class Assert
+{
+    /** @var string */
+    protected static $lazyAssertionExceptionClass = 'Assert\LazyAssertionException';
+
+    /** @var string */
+    protected static $assertionClass = 'Assert\Assertion';
+
+    /**
+     * Start validation on a value, returns {@link AssertionChain}.
+     *
+     * The invocation of this method starts an assertion chain
+     * that is happening on the passed value.
+     *
+     * @example
+     *
+     *  Assert::that($value)->notEmpty()->integer();
+     *  Assert::that($value)->nullOr()->string()->startsWith("Foo");
+     *
+     * The assertion chain can be stateful, that means be careful when you reuse
+     * it. You should never pass around the chain.
+     *
+     * @param mixed $value
+     * @param string $defaultMessage
+     * @param string $defaultPropertyPath
+     *
+     * @return \Assert\AssertionChain
+     */
+    public static function that($value, $defaultMessage = null, $defaultPropertyPath = null)
+    {
+        $assertionChain = new AssertionChain($value, $defaultMessage, $defaultPropertyPath);
+
+        return $assertionChain
+            ->setAssertionClassName(static::$assertionClass);
+    }
+
+    /**
+     * Start validation on a set of values, returns {@link AssertionChain}.
+     *
+     * @param mixed $values
+     * @param string $defaultMessage
+     * @param string $defaultPropertyPath
+     *
+     * @return \Assert\AssertionChain
+     */
+    public static function thatAll($values, $defaultMessage = null, $defaultPropertyPath = null)
+    {
+        return static::that($values, $defaultMessage, $defaultPropertyPath)->all();
+    }
+
+    /**
+     * Start validation and allow NULL, returns {@link AssertionChain}.
+     *
+     * @param mixed $value
+     * @param string $defaultMessage
+     * @param string $defaultPropertyPath
+     *
+     * @return \Assert\AssertionChain
+     */
+    public static function thatNullOr($value, $defaultMessage = null, $defaultPropertyPath = null)
+    {
+        return static::that($value, $defaultMessage, $defaultPropertyPath)->nullOr();
+    }
+
+    /**
+     * Create a lazy assertion object.
+     *
+     * @return \Assert\LazyAssertion
+     */
+    public static function lazy()
+    {
+        $lazyAssertion = new LazyAssertion();
+
+        return $lazyAssertion
+            ->setExceptionClass(static::$lazyAssertionExceptionClass);
+    }
+}

--- a/libs/TLS/Assert/Assertion.php
+++ b/libs/TLS/Assert/Assertion.php
@@ -1,0 +1,2582 @@
+<?php
+
+/**
+ * Assert
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace Assert;
+
+use BadMethodCallException;
+
+/**
+ * Assert library.
+ *
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * @method static bool allAlnum(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is alphanumeric for all values.
+ * @method static bool allBetween(mixed $value, mixed $lowerLimit, mixed $upperLimit, string $message = null, string $propertyPath = null) Assert that a value is greater or equal than a lower limit, and less than or equal to an upper limit for all values.
+ * @method static bool allBetweenExclusive(mixed $value, mixed $lowerLimit, mixed $upperLimit, string $message = null, string $propertyPath = null) Assert that a value is greater than a lower limit, and less than an upper limit for all values.
+ * @method static bool allBetweenLength(mixed $value, int $minLength, int $maxLength, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string length is between min, max lengths for all values.
+ * @method static bool allBoolean(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is php boolean for all values.
+ * @method static bool allChoice(mixed $value, array $choices, string | callable $message = null, string $propertyPath = null) Assert that value is in array of choices for all values.
+ * @method static bool allChoicesNotEmpty(array $values, array $choices, string | callable $message = null, string $propertyPath = null) Determines if the values array has every choice as key and that this choice has content for all values.
+ * @method static bool allClassExists(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that the class exists for all values.
+ * @method static bool allContains(mixed $string, string $needle, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string contains a sequence of chars for all values.
+ * @method static bool allCount(array | \Countable $countable, array | \Countable $count, string $message = null, string $propertyPath = null) Assert that the count of countable is equal to count for all values.
+ * @method static bool allDate(string $value, string $format, string | callable $message = null, string $propertyPath = null) Assert that date is valid and corresponds to the given format for all values.
+ * @method static bool allDefined(mixed $constant, string | callable $message = null, string $propertyPath = null) Assert that a constant is defined for all values.
+ * @method static bool allDigit(mixed $value, string | callable $message = null, string $propertyPath = null) Validates if an integer or integerish is a digit for all values.
+ * @method static bool allDirectory(string $value, string | callable $message = null, string $propertyPath = null) Assert that a directory exists for all values.
+ * @method static bool allE164(string $value, string | callable $message = null, string $propertyPath = null) Assert that the given string is a valid E164 Phone Number for all values.
+ * @method static bool allEmail(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is an email adress (using input_filter/FILTER_VALIDATE_EMAIL) for all values.
+ * @method static bool allEndsWith(mixed $string, string $needle, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string ends with a sequence of chars for all values.
+ * @method static bool allEq(mixed $value, mixed $value2, string | callable $message = null, string $propertyPath = null) Assert that two values are equal (using ==) for all values.
+ * @method static bool allExtensionLoaded(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that extension is loaded for all values.
+ * @method static bool allExtensionVersion(string $extension, string $operator, mixed $version, string | callable $message = null, string $propertyPath = null) Assert that extension is loaded and a specific version is installed for all values.
+ * @method static bool allFalse(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that the value is boolean False for all values.
+ * @method static bool allFile(string $value, string | callable $message = null, string $propertyPath = null) Assert that a file exists for all values.
+ * @method static bool allFloat(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is a php float for all values.
+ * @method static bool allGreaterOrEqualThan(mixed $value, mixed $limit, string | callable $message = null, string $propertyPath = null) Determines if the value is greater or equal than given limit for all values.
+ * @method static bool allGreaterThan(mixed $value, mixed $limit, string | callable $message = null, string $propertyPath = null) Determines if the value is greater than given limit for all values.
+ * @method static bool allImplementsInterface(mixed $class, string $interfaceName, string | callable $message = null, string $propertyPath = null) Assert that the class implements the interface for all values.
+ * @method static bool allInArray(mixed $value, array $choices, string | callable $message = null, string $propertyPath = null) Assert that value is in array of choices. This is an alias of Assertion::choice() for all values.
+ * @method static bool allInteger(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is a php integer for all values.
+ * @method static bool allIntegerish(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is a php integer'ish for all values.
+ * @method static bool allInterfaceExists(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that the interface exists for all values.
+ * @method static bool allIp(string $value, int $flag = null, string | callable $message = null, string $propertyPath = null) Assert that value is an IPv4 or IPv6 address for all values.
+ * @method static bool allIpv4(string $value, int $flag = null, string | callable $message = null, string $propertyPath = null) Assert that value is an IPv4 address for all values.
+ * @method static bool allIpv6(string $value, int $flag = null, string | callable $message = null, string $propertyPath = null) Assert that value is an IPv6 address for all values.
+ * @method static bool allIsArray(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is an array for all values.
+ * @method static bool allIsArrayAccessible(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is an array or an array-accessible object for all values.
+ * @method static bool allIsCallable(mixed $value, string | callable $message = null, string $propertyPath = null) Determines that the provided value is callable for all values.
+ * @method static bool allIsInstanceOf(mixed $value, string $className, string | callable $message = null, string $propertyPath = null) Assert that value is instance of given class-name for all values.
+ * @method static bool allIsJsonString(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that the given string is a valid json string for all values.
+ * @method static bool allIsObject(mixed $value, string | callable $message = null, string $propertyPath = null) Determines that the provided value is an object for all values.
+ * @method static bool allIsResource(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is a resource for all values.
+ * @method static bool allIsTraversable(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is an array or a traversable object for all values.
+ * @method static bool allKeyExists(mixed $value, string | int $key, string | callable $message = null, string $propertyPath = null) Assert that key exists in an array for all values.
+ * @method static bool allKeyIsset(mixed $value, string | int $key, string | callable $message = null, string $propertyPath = null) Assert that key exists in an array/array-accessible object using isset() for all values.
+ * @method static bool allKeyNotExists(mixed $value, string | int $key, string | callable $message = null, string $propertyPath = null) Assert that key does not exist in an array for all values.
+ * @method static bool allLength(mixed $value, int $length, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string has a given length for all values.
+ * @method static bool allLessOrEqualThan(mixed $value, mixed $limit, string | callable $message = null, string $propertyPath = null) Determines if the value is less or than given limit for all values.
+ * @method static bool allLessThan(mixed $value, mixed $limit, string | callable $message = null, string $propertyPath = null) Determines if the value is less than given limit for all values.
+ * @method static bool allMax(mixed $value, mixed $maxValue, string | callable $message = null, string $propertyPath = null) Assert that a number is smaller as a given limit for all values.
+ * @method static bool allMaxLength(mixed $value, int $maxLength, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string value is not longer than $maxLength chars for all values.
+ * @method static bool allMethodExists(string $value, mixed $object, string | callable $message = null, string $propertyPath = null) Determines that the named method is defined in the provided object for all values.
+ * @method static bool allMin(mixed $value, mixed $minValue, string | callable $message = null, string $propertyPath = null) Assert that a value is at least as big as a given limit for all values.
+ * @method static bool allMinLength(mixed $value, int $minLength, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that a string is at least $minLength chars long for all values.
+ * @method static bool allNoContent(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is empty for all values.
+ * @method static bool allNotBlank(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is not blank for all values.
+ * @method static bool allNotEmpty(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is not empty for all values.
+ * @method static bool allNotEmptyKey(mixed $value, string | int $key, string | callable $message = null, string $propertyPath = null) Assert that key exists in an array/array-accessible object and its value is not empty for all values.
+ * @method static bool allNotEq(mixed $value1, mixed $value2, string | callable $message = null, string $propertyPath = null) Assert that two values are not equal (using ==) for all values.
+ * @method static bool allNotInArray(mixed $value, array $choices, string | callable $message = null, string $propertyPath = null) Assert that value is not in array of choices for all values.
+ * @method static bool allNotIsInstanceOf(mixed $value, string $className, string | callable $message = null, string $propertyPath = null) Assert that value is not instance of given class-name for all values.
+ * @method static bool allNotNull(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is not null for all values.
+ * @method static bool allNotSame(mixed $value1, mixed $value2, string | callable $message = null, string $propertyPath = null) Assert that two values are not the same (using ===) for all values.
+ * @method static bool allNull(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is null for all values.
+ * @method static bool allNumeric(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is numeric for all values.
+ * @method static bool allObjectOrClass(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that the value is an object, or a class that exists for all values.
+ * @method static bool allPhpVersion(string $operator, mixed $version, string | callable $message = null, string $propertyPath = null) Assert on PHP version for all values.
+ * @method static bool allPropertiesExist(mixed $value, array $properties, string | callable $message = null, string $propertyPath = null) Assert that the value is an object or class, and that the properties all exist for all values.
+ * @method static bool allPropertyExists(mixed $value, string $property, string | callable $message = null, string $propertyPath = null) Assert that the value is an object or class, and that the property exists for all values.
+ * @method static bool allRange(mixed $value, mixed $minValue, mixed $maxValue, string | callable $message = null, string $propertyPath = null) Assert that value is in range of numbers for all values.
+ * @method static bool allReadable(string $value, string | callable $message = null, string $propertyPath = null) Assert that the value is something readable for all values.
+ * @method static bool allRegex(mixed $value, string $pattern, string | callable $message = null, string $propertyPath = null) Assert that value matches a regex for all values.
+ * @method static bool allSame(mixed $value, mixed $value2, string | callable $message = null, string $propertyPath = null) Assert that two values are the same (using ===) for all values.
+ * @method static bool allSatisfy(mixed $value, callable $callback, string | callable $message = null, string $propertyPath = null) Assert that the provided value is valid according to a callback for all values.
+ * @method static bool allScalar(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is a PHP scalar for all values.
+ * @method static bool allStartsWith(mixed $string, string $needle, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string starts with a sequence of chars for all values.
+ * @method static bool allString(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is a string for all values.
+ * @method static bool allSubclassOf(mixed $value, string $className, string | callable $message = null, string $propertyPath = null) Assert that value is subclass of given class-name for all values.
+ * @method static bool allTrue(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that the value is boolean True for all values.
+ * @method static bool allUrl(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is an URL for all values.
+ * @method static bool allUuid(string $value, string | callable $message = null, string $propertyPath = null) Assert that the given string is a valid UUID for all values.
+ * @method static bool allVersion(string $version1, string $operator, string $version2, string | callable $message = null, string $propertyPath = null) Assert comparison of two versions for all values.
+ * @method static bool allWriteable(string $value, string | callable $message = null, string $propertyPath = null) Assert that the value is something writeable for all values.
+ * @method static bool nullOrAlnum(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is alphanumeric or that the value is null.
+ * @method static bool nullOrBetween(mixed $value, mixed $lowerLimit, mixed $upperLimit, string $message = null, string $propertyPath = null) Assert that a value is greater or equal than a lower limit, and less than or equal to an upper limit or that the value is null.
+ * @method static bool nullOrBetweenExclusive(mixed $value, mixed $lowerLimit, mixed $upperLimit, string $message = null, string $propertyPath = null) Assert that a value is greater than a lower limit, and less than an upper limit or that the value is null.
+ * @method static bool nullOrBetweenLength(mixed $value, int $minLength, int $maxLength, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string length is between min, max lengths or that the value is null.
+ * @method static bool nullOrBoolean(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is php boolean or that the value is null.
+ * @method static bool nullOrChoice(mixed $value, array $choices, string | callable $message = null, string $propertyPath = null) Assert that value is in array of choices or that the value is null.
+ * @method static bool nullOrChoicesNotEmpty(array $values, array $choices, string | callable $message = null, string $propertyPath = null) Determines if the values array has every choice as key and that this choice has content or that the value is null.
+ * @method static bool nullOrClassExists(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that the class exists or that the value is null.
+ * @method static bool nullOrContains(mixed $string, string $needle, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string contains a sequence of chars or that the value is null.
+ * @method static bool nullOrCount(array | \Countable $countable, array | \Countable $count, string $message = null, string $propertyPath = null) Assert that the count of countable is equal to count or that the value is null.
+ * @method static bool nullOrDate(string $value, string $format, string | callable $message = null, string $propertyPath = null) Assert that date is valid and corresponds to the given format or that the value is null.
+ * @method static bool nullOrDefined(mixed $constant, string | callable $message = null, string $propertyPath = null) Assert that a constant is defined or that the value is null.
+ * @method static bool nullOrDigit(mixed $value, string | callable $message = null, string $propertyPath = null) Validates if an integer or integerish is a digit or that the value is null.
+ * @method static bool nullOrDirectory(string $value, string | callable $message = null, string $propertyPath = null) Assert that a directory exists or that the value is null.
+ * @method static bool nullOrE164(string $value, string | callable $message = null, string $propertyPath = null) Assert that the given string is a valid E164 Phone Number or that the value is null.
+ * @method static bool nullOrEmail(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is an email adress (using input_filter/FILTER_VALIDATE_EMAIL) or that the value is null.
+ * @method static bool nullOrEndsWith(mixed $string, string $needle, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string ends with a sequence of chars or that the value is null.
+ * @method static bool nullOrEq(mixed $value, mixed $value2, string | callable $message = null, string $propertyPath = null) Assert that two values are equal (using ==) or that the value is null.
+ * @method static bool nullOrExtensionLoaded(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that extension is loaded or that the value is null.
+ * @method static bool nullOrExtensionVersion(string $extension, string $operator, mixed $version, string | callable $message = null, string $propertyPath = null) Assert that extension is loaded and a specific version is installed or that the value is null.
+ * @method static bool nullOrFalse(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that the value is boolean False or that the value is null.
+ * @method static bool nullOrFile(string $value, string | callable $message = null, string $propertyPath = null) Assert that a file exists or that the value is null.
+ * @method static bool nullOrFloat(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is a php float or that the value is null.
+ * @method static bool nullOrGreaterOrEqualThan(mixed $value, mixed $limit, string | callable $message = null, string $propertyPath = null) Determines if the value is greater or equal than given limit or that the value is null.
+ * @method static bool nullOrGreaterThan(mixed $value, mixed $limit, string | callable $message = null, string $propertyPath = null) Determines if the value is greater than given limit or that the value is null.
+ * @method static bool nullOrImplementsInterface(mixed $class, string $interfaceName, string | callable $message = null, string $propertyPath = null) Assert that the class implements the interface or that the value is null.
+ * @method static bool nullOrInArray(mixed $value, array $choices, string | callable $message = null, string $propertyPath = null) Assert that value is in array of choices. This is an alias of Assertion::choice() or that the value is null.
+ * @method static bool nullOrInteger(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is a php integer or that the value is null.
+ * @method static bool nullOrIntegerish(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is a php integer'ish or that the value is null.
+ * @method static bool nullOrInterfaceExists(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that the interface exists or that the value is null.
+ * @method static bool nullOrIp(string $value, int $flag = null, string | callable $message = null, string $propertyPath = null) Assert that value is an IPv4 or IPv6 address or that the value is null.
+ * @method static bool nullOrIpv4(string $value, int $flag = null, string | callable $message = null, string $propertyPath = null) Assert that value is an IPv4 address or that the value is null.
+ * @method static bool nullOrIpv6(string $value, int $flag = null, string | callable $message = null, string $propertyPath = null) Assert that value is an IPv6 address or that the value is null.
+ * @method static bool nullOrIsArray(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is an array or that the value is null.
+ * @method static bool nullOrIsArrayAccessible(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is an array or an array-accessible object or that the value is null.
+ * @method static bool nullOrIsCallable(mixed $value, string | callable $message = null, string $propertyPath = null) Determines that the provided value is callable or that the value is null.
+ * @method static bool nullOrIsInstanceOf(mixed $value, string $className, string | callable $message = null, string $propertyPath = null) Assert that value is instance of given class-name or that the value is null.
+ * @method static bool nullOrIsJsonString(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that the given string is a valid json string or that the value is null.
+ * @method static bool nullOrIsObject(mixed $value, string | callable $message = null, string $propertyPath = null) Determines that the provided value is an object or that the value is null.
+ * @method static bool nullOrIsResource(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is a resource or that the value is null.
+ * @method static bool nullOrIsTraversable(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is an array or a traversable object or that the value is null.
+ * @method static bool nullOrKeyExists(mixed $value, string | int $key, string | callable $message = null, string $propertyPath = null) Assert that key exists in an array or that the value is null.
+ * @method static bool nullOrKeyIsset(mixed $value, string | int $key, string | callable $message = null, string $propertyPath = null) Assert that key exists in an array/array-accessible object using isset() or that the value is null.
+ * @method static bool nullOrKeyNotExists(mixed $value, string | int $key, string | callable $message = null, string $propertyPath = null) Assert that key does not exist in an array or that the value is null.
+ * @method static bool nullOrLength(mixed $value, int $length, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string has a given length or that the value is null.
+ * @method static bool nullOrLessOrEqualThan(mixed $value, mixed $limit, string | callable $message = null, string $propertyPath = null) Determines if the value is less or than given limit or that the value is null.
+ * @method static bool nullOrLessThan(mixed $value, mixed $limit, string | callable $message = null, string $propertyPath = null) Determines if the value is less than given limit or that the value is null.
+ * @method static bool nullOrMax(mixed $value, mixed $maxValue, string | callable $message = null, string $propertyPath = null) Assert that a number is smaller as a given limit or that the value is null.
+ * @method static bool nullOrMaxLength(mixed $value, int $maxLength, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string value is not longer than $maxLength chars or that the value is null.
+ * @method static bool nullOrMethodExists(string $value, mixed $object, string | callable $message = null, string $propertyPath = null) Determines that the named method is defined in the provided object or that the value is null.
+ * @method static bool nullOrMin(mixed $value, mixed $minValue, string | callable $message = null, string $propertyPath = null) Assert that a value is at least as big as a given limit or that the value is null.
+ * @method static bool nullOrMinLength(mixed $value, int $minLength, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that a string is at least $minLength chars long or that the value is null.
+ * @method static bool nullOrNoContent(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is empty or that the value is null.
+ * @method static bool nullOrNotBlank(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is not blank or that the value is null.
+ * @method static bool nullOrNotEmpty(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is not empty or that the value is null.
+ * @method static bool nullOrNotEmptyKey(mixed $value, string | int $key, string | callable $message = null, string $propertyPath = null) Assert that key exists in an array/array-accessible object and its value is not empty or that the value is null.
+ * @method static bool nullOrNotEq(mixed $value1, mixed $value2, string | callable $message = null, string $propertyPath = null) Assert that two values are not equal (using ==) or that the value is null.
+ * @method static bool nullOrNotInArray(mixed $value, array $choices, string | callable $message = null, string $propertyPath = null) Assert that value is not in array of choices or that the value is null.
+ * @method static bool nullOrNotIsInstanceOf(mixed $value, string $className, string | callable $message = null, string $propertyPath = null) Assert that value is not instance of given class-name or that the value is null.
+ * @method static bool nullOrNotNull(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is not null or that the value is null.
+ * @method static bool nullOrNotSame(mixed $value1, mixed $value2, string | callable $message = null, string $propertyPath = null) Assert that two values are not the same (using ===) or that the value is null.
+ * @method static bool nullOrNull(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is null or that the value is null.
+ * @method static bool nullOrNumeric(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is numeric or that the value is null.
+ * @method static bool nullOrObjectOrClass(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that the value is an object, or a class that exists or that the value is null.
+ * @method static bool nullOrPhpVersion(string $operator, mixed $version, string | callable $message = null, string $propertyPath = null) Assert on PHP version or that the value is null.
+ * @method static bool nullOrPropertiesExist(mixed $value, array $properties, string | callable $message = null, string $propertyPath = null) Assert that the value is an object or class, and that the properties all exist or that the value is null.
+ * @method static bool nullOrPropertyExists(mixed $value, string $property, string | callable $message = null, string $propertyPath = null) Assert that the value is an object or class, and that the property exists or that the value is null.
+ * @method static bool nullOrRange(mixed $value, mixed $minValue, mixed $maxValue, string | callable $message = null, string $propertyPath = null) Assert that value is in range of numbers or that the value is null.
+ * @method static bool nullOrReadable(string $value, string | callable $message = null, string $propertyPath = null) Assert that the value is something readable or that the value is null.
+ * @method static bool nullOrRegex(mixed $value, string $pattern, string | callable $message = null, string $propertyPath = null) Assert that value matches a regex or that the value is null.
+ * @method static bool nullOrSame(mixed $value, mixed $value2, string | callable $message = null, string $propertyPath = null) Assert that two values are the same (using ===) or that the value is null.
+ * @method static bool nullOrSatisfy(mixed $value, callable $callback, string | callable $message = null, string $propertyPath = null) Assert that the provided value is valid according to a callback or that the value is null.
+ * @method static bool nullOrScalar(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is a PHP scalar or that the value is null.
+ * @method static bool nullOrStartsWith(mixed $string, string $needle, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string starts with a sequence of chars or that the value is null.
+ * @method static bool nullOrString(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is a string or that the value is null.
+ * @method static bool nullOrSubclassOf(mixed $value, string $className, string | callable $message = null, string $propertyPath = null) Assert that value is subclass of given class-name or that the value is null.
+ * @method static bool nullOrTrue(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that the value is boolean True or that the value is null.
+ * @method static bool nullOrUrl(mixed $value, string | callable $message = null, string $propertyPath = null) Assert that value is an URL or that the value is null.
+ * @method static bool nullOrUuid(string $value, string | callable $message = null, string $propertyPath = null) Assert that the given string is a valid UUID or that the value is null.
+ * @method static bool nullOrVersion(string $version1, string $operator, string $version2, string | callable $message = null, string $propertyPath = null) Assert comparison of two versions or that the value is null.
+ * @method static bool nullOrWriteable(string $value, string | callable $message = null, string $propertyPath = null) Assert that the value is something writeable or that the value is null.
+ */
+class Assertion
+{
+    const INVALID_FLOAT = 9;
+    const INVALID_INTEGER = 10;
+    const INVALID_DIGIT = 11;
+    const INVALID_INTEGERISH = 12;
+    const INVALID_BOOLEAN = 13;
+    const VALUE_EMPTY = 14;
+    const VALUE_NULL = 15;
+    const VALUE_NOT_NULL = 25;
+    const INVALID_STRING = 16;
+    const INVALID_REGEX = 17;
+    const INVALID_MIN_LENGTH = 18;
+    const INVALID_MAX_LENGTH = 19;
+    const INVALID_STRING_START = 20;
+    const INVALID_STRING_CONTAINS = 21;
+    const INVALID_CHOICE = 22;
+    const INVALID_NUMERIC = 23;
+    const INVALID_ARRAY = 24;
+    const INVALID_KEY_EXISTS = 26;
+    const INVALID_NOT_BLANK = 27;
+    const INVALID_INSTANCE_OF = 28;
+    const INVALID_SUBCLASS_OF = 29;
+    const INVALID_RANGE = 30;
+    const INVALID_ALNUM = 31;
+    const INVALID_TRUE = 32;
+    const INVALID_EQ = 33;
+    const INVALID_SAME = 34;
+    const INVALID_MIN = 35;
+    const INVALID_MAX = 36;
+    const INVALID_LENGTH = 37;
+    const INVALID_FALSE = 38;
+    const INVALID_STRING_END = 39;
+    const INVALID_UUID = 40;
+    const INVALID_COUNT = 41;
+    const INVALID_NOT_EQ = 42;
+    const INVALID_NOT_SAME = 43;
+    const INVALID_TRAVERSABLE = 44;
+    const INVALID_ARRAY_ACCESSIBLE = 45;
+    const INVALID_KEY_ISSET = 46;
+    const INVALID_VALUE_IN_ARRAY = 47;
+    const INVALID_E164 = 48;
+    const INVALID_DIRECTORY = 101;
+    const INVALID_FILE = 102;
+    const INVALID_READABLE = 103;
+    const INVALID_WRITEABLE = 104;
+    const INVALID_CLASS = 105;
+    const INVALID_INTERFACE = 106;
+    const INVALID_EMAIL = 201;
+    const INTERFACE_NOT_IMPLEMENTED = 202;
+    const INVALID_URL = 203;
+    const INVALID_NOT_INSTANCE_OF = 204;
+    const VALUE_NOT_EMPTY = 205;
+    const INVALID_JSON_STRING = 206;
+    const INVALID_OBJECT = 207;
+    const INVALID_METHOD = 208;
+    const INVALID_SCALAR = 209;
+    const INVALID_LESS = 210;
+    const INVALID_LESS_OR_EQUAL = 211;
+    const INVALID_GREATER = 212;
+    const INVALID_GREATER_OR_EQUAL = 213;
+    const INVALID_DATE = 214;
+    const INVALID_CALLABLE = 215;
+    const INVALID_KEY_NOT_EXISTS = 216;
+    const INVALID_SATISFY = 217;
+    const INVALID_IP = 218;
+    const INVALID_BETWEEN = 219;
+    const INVALID_BETWEEN_EXCLUSIVE = 220;
+    const INVALID_EXTENSION = 222;
+    const INVALID_CONSTANT = 221;
+    const INVALID_VERSION = 223;
+    const INVALID_PROPERTY = 224;
+    const INVALID_RESOURCE = 225;
+
+    /**
+     * Exception to throw when an assertion failed.
+     *
+     * @var string
+     */
+    protected static $exceptionClass = 'Assert\InvalidArgumentException';
+
+    /**
+     * Helper method that handles building the assertion failure exceptions.
+     * They are returned from this method so that the stack trace still shows
+     * the assertions method.
+     *
+     * @param mixed $value
+     * @param string|callable $message
+     * @param int $code
+     * @param string|null $propertyPath
+     * @param array $constraints
+     *
+     * @return mixed
+     */
+    protected static function createException($value, $message, $code, $propertyPath = null, array $constraints = [])
+    {
+        $exceptionClass = static::$exceptionClass;
+
+        return new $exceptionClass($message, $code, $propertyPath, $value, $constraints);
+    }
+
+    /**
+     * Assert that two values are equal (using == ).
+     *
+     * @param mixed $value
+     * @param mixed $value2
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function eq($value, $value2, $message = null, $propertyPath = null)
+    {
+        if ($value != $value2) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" does not equal expected value "%s".',
+                static::stringify($value),
+                static::stringify($value2)
+            );
+
+            throw static::createException($value, $message, static::INVALID_EQ, $propertyPath, ['expected' => $value2]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that two values are the same (using ===).
+     *
+     * @param mixed $value
+     * @param mixed $value2
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function same($value, $value2, $message = null, $propertyPath = null)
+    {
+        if ($value !== $value2) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is not the same as expected value "%s".',
+                static::stringify($value),
+                static::stringify($value2)
+            );
+
+            throw static::createException($value, $message, static::INVALID_SAME, $propertyPath, ['expected' => $value2]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that two values are not equal (using == ).
+     *
+     * @param mixed $value1
+     * @param mixed $value2
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function notEq($value1, $value2, $message = null, $propertyPath = null)
+    {
+        if ($value1 == $value2) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is equal to expected value "%s".',
+                static::stringify($value1),
+                static::stringify($value2)
+            );
+            throw static::createException($value1, $message, static::INVALID_NOT_EQ, $propertyPath, ['expected' => $value2]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that two values are not the same (using === ).
+     *
+     * @param mixed $value1
+     * @param mixed $value2
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function notSame($value1, $value2, $message = null, $propertyPath = null)
+    {
+        if ($value1 === $value2) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is the same as expected value "%s".',
+                static::stringify($value1),
+                static::stringify($value2)
+            );
+            throw static::createException($value1, $message, static::INVALID_NOT_SAME, $propertyPath, ['expected' => $value2]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is not in array of choices.
+     *
+     * @param mixed $value
+     * @param array $choices
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function notInArray($value, array $choices, $message = null, $propertyPath = null)
+    {
+        if (\in_array($value, $choices) === true) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is in given "%s".',
+                static::stringify($value),
+                static::stringify($choices)
+            );
+            throw static::createException($value, $message, static::INVALID_VALUE_IN_ARRAY, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is a php integer.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function integer($value, $message = null, $propertyPath = null)
+    {
+        if (!\is_int($value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is not an integer.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_INTEGER, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is a php float.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function float($value, $message = null, $propertyPath = null)
+    {
+        if (!\is_float($value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is not a float.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_FLOAT, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Validates if an integer or integerish is a digit.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function digit($value, $message = null, $propertyPath = null)
+    {
+        if (!\ctype_digit((string)$value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is not a digit.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_DIGIT, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is a php integer'ish.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function integerish($value, $message = null, $propertyPath = null)
+    {
+        if (\is_resource($value) || \is_object($value) || \strval(\intval($value)) != $value || \is_bool($value) || \is_null($value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is not an integer or a number castable to integer.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_INTEGERISH, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is php boolean.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function boolean($value, $message = null, $propertyPath = null)
+    {
+        if (!\is_bool($value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is not a boolean.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_BOOLEAN, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is a PHP scalar.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function scalar($value, $message = null, $propertyPath = null)
+    {
+        if (!\is_scalar($value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is not a scalar.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_SCALAR, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is not empty.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function notEmpty($value, $message = null, $propertyPath = null)
+    {
+        if (empty($value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is empty, but non empty value was expected.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::VALUE_EMPTY, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is empty.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function noContent($value, $message = null, $propertyPath = null)
+    {
+        if (!empty($value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is not empty, but empty value was expected.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::VALUE_NOT_EMPTY, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is null.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function null($value, $message = null, $propertyPath = null)
+    {
+        if ($value !== null) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is not null, but null value was expected.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::VALUE_NOT_NULL, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is not null.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function notNull($value, $message = null, $propertyPath = null)
+    {
+        if ($value === null) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is null, but non null value was expected.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::VALUE_NULL, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is a string.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function string($value, $message = null, $propertyPath = null)
+    {
+        if (!\is_string($value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" expected to be string, type %s given.',
+                static::stringify($value),
+                \gettype($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_STRING, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value matches a regex.
+     *
+     * @param mixed $value
+     * @param string $pattern
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function regex($value, $pattern, $message = null, $propertyPath = null)
+    {
+        static::string($value, $message, $propertyPath);
+
+        if (!\preg_match($pattern, $value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" does not match expression.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_REGEX, $propertyPath, ['pattern' => $pattern]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that string has a given length.
+     *
+     * @param mixed $value
+     * @param int $length
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     * @param string $encoding
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function length($value, $length, $message = null, $propertyPath = null, $encoding = 'utf8')
+    {
+        static::string($value, $message, $propertyPath);
+
+        if (\mb_strlen($value, $encoding) !== $length) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" has to be %d exactly characters long, but length is %d.',
+                static::stringify($value),
+                $length,
+                \mb_strlen($value, $encoding)
+            );
+
+            $constraints = ['length' => $length, 'encoding' => $encoding];
+            throw static::createException($value, $message, static::INVALID_LENGTH, $propertyPath, $constraints);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that a string is at least $minLength chars long.
+     *
+     * @param mixed $value
+     * @param int $minLength
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     * @param string $encoding
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function minLength($value, $minLength, $message = null, $propertyPath = null, $encoding = 'utf8')
+    {
+        static::string($value, $message, $propertyPath);
+
+        if (\mb_strlen($value, $encoding) < $minLength) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is too short, it should have at least %d characters, but only has %d characters.',
+                static::stringify($value),
+                $minLength,
+                \mb_strlen($value, $encoding)
+            );
+
+            $constraints = ['min_length' => $minLength, 'encoding' => $encoding];
+            throw static::createException($value, $message, static::INVALID_MIN_LENGTH, $propertyPath, $constraints);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that string value is not longer than $maxLength chars.
+     *
+     * @param mixed $value
+     * @param int $maxLength
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     * @param string $encoding
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function maxLength($value, $maxLength, $message = null, $propertyPath = null, $encoding = 'utf8')
+    {
+        static::string($value, $message, $propertyPath);
+
+        if (\mb_strlen($value, $encoding) > $maxLength) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is too long, it should have no more than %d characters, but has %d characters.',
+                static::stringify($value),
+                $maxLength,
+                \mb_strlen($value, $encoding)
+            );
+
+            $constraints = ['max_length' => $maxLength, 'encoding' => $encoding];
+            throw static::createException($value, $message, static::INVALID_MAX_LENGTH, $propertyPath, $constraints);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that string length is between min,max lengths.
+     *
+     * @param mixed $value
+     * @param int $minLength
+     * @param int $maxLength
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     * @param string $encoding
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function betweenLength($value, $minLength, $maxLength, $message = null, $propertyPath = null, $encoding = 'utf8')
+    {
+        static::string($value, $message, $propertyPath);
+        static::minLength($value, $minLength, $message, $propertyPath, $encoding);
+        static::maxLength($value, $maxLength, $message, $propertyPath, $encoding);
+
+        return true;
+    }
+
+    /**
+     * Assert that string starts with a sequence of chars.
+     *
+     * @param mixed $string
+     * @param string $needle
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     * @param string $encoding
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function startsWith($string, $needle, $message = null, $propertyPath = null, $encoding = 'utf8')
+    {
+        static::string($string, $message, $propertyPath);
+
+        if (\mb_strpos($string, $needle, null, $encoding) !== 0) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" does not start with "%s".',
+                static::stringify($string),
+                static::stringify($needle)
+            );
+
+            $constraints = ['needle' => $needle, 'encoding' => $encoding];
+            throw static::createException($string, $message, static::INVALID_STRING_START, $propertyPath, $constraints);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that string ends with a sequence of chars.
+     *
+     * @param mixed $string
+     * @param string $needle
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     * @param string $encoding
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function endsWith($string, $needle, $message = null, $propertyPath = null, $encoding = 'utf8')
+    {
+        static::string($string, $message, $propertyPath);
+
+        $stringPosition = \mb_strlen($string, $encoding) - \mb_strlen($needle, $encoding);
+
+        if (\mb_strripos($string, $needle, null, $encoding) !== $stringPosition) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" does not end with "%s".',
+                static::stringify($string),
+                static::stringify($needle)
+            );
+
+            $constraints = ['needle' => $needle, 'encoding' => $encoding];
+            throw static::createException($string, $message, static::INVALID_STRING_END, $propertyPath, $constraints);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that string contains a sequence of chars.
+     *
+     * @param mixed $string
+     * @param string $needle
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     * @param string $encoding
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function contains($string, $needle, $message = null, $propertyPath = null, $encoding = 'utf8')
+    {
+        static::string($string, $message, $propertyPath);
+
+        if (\mb_strpos($string, $needle, null, $encoding) === false) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" does not contain "%s".',
+                static::stringify($string),
+                static::stringify($needle)
+            );
+
+            $constraints = ['needle' => $needle, 'encoding' => $encoding];
+            throw static::createException($string, $message, static::INVALID_STRING_CONTAINS, $propertyPath, $constraints);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is in array of choices.
+     *
+     * @param mixed $value
+     * @param array $choices
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function choice($value, array $choices, $message = null, $propertyPath = null)
+    {
+        if (!\in_array($value, $choices, true)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is not an element of the valid values: %s',
+                static::stringify($value),
+                \implode(', ', \array_map([\get_called_class(), 'stringify'], $choices))
+            );
+
+            throw static::createException($value, $message, static::INVALID_CHOICE, $propertyPath, ['choices' => $choices]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is in array of choices.
+     *
+     * This is an alias of {@see choice()}.
+     *
+     * @aliasOf choice()
+     *
+     * @param mixed $value
+     * @param array $choices
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     */
+    public static function inArray($value, array $choices, $message = null, $propertyPath = null)
+    {
+        return static::choice($value, $choices, $message, $propertyPath);
+    }
+
+    /**
+     * Assert that value is numeric.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function numeric($value, $message = null, $propertyPath = null)
+    {
+        if (!\is_numeric($value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is not numeric.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_NUMERIC, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is a resource.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function isResource($value, $message = null, $propertyPath = null)
+    {
+        if (!\is_resource($value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is not a resource.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_RESOURCE, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is an array.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function isArray($value, $message = null, $propertyPath = null)
+    {
+        if (!\is_array($value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is not an array.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_ARRAY, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is an array or a traversable object.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function isTraversable($value, $message = null, $propertyPath = null)
+    {
+        if (!\is_array($value) && !$value instanceof \Traversable) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is not an array and does not implement Traversable.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_TRAVERSABLE, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is an array or an array-accessible object.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function isArrayAccessible($value, $message = null, $propertyPath = null)
+    {
+        if (!\is_array($value) && !$value instanceof \ArrayAccess) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is not an array and does not implement ArrayAccess.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_ARRAY_ACCESSIBLE, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that key exists in an array.
+     *
+     * @param mixed $value
+     * @param string|int $key
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function keyExists($value, $key, $message = null, $propertyPath = null)
+    {
+        static::isArray($value, $message, $propertyPath);
+
+        if (!\array_key_exists($key, $value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Array does not contain an element with key "%s"',
+                static::stringify($key)
+            );
+
+            throw static::createException($value, $message, static::INVALID_KEY_EXISTS, $propertyPath, ['key' => $key]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that key does not exist in an array.
+     *
+     * @param mixed $value
+     * @param string|int $key
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function keyNotExists($value, $key, $message = null, $propertyPath = null)
+    {
+        static::isArray($value, $message, $propertyPath);
+
+        if (\array_key_exists($key, $value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Array contains an element with key "%s"',
+                static::stringify($key)
+            );
+
+            throw static::createException($value, $message, static::INVALID_KEY_NOT_EXISTS, $propertyPath, ['key' => $key]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that key exists in an array/array-accessible object using isset().
+     *
+     * @param mixed $value
+     * @param string|int $key
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function keyIsset($value, $key, $message = null, $propertyPath = null)
+    {
+        static::isArrayAccessible($value, $message, $propertyPath);
+
+        if (!isset($value[$key])) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'The element with key "%s" was not found',
+                static::stringify($key)
+            );
+
+            throw static::createException($value, $message, static::INVALID_KEY_ISSET, $propertyPath, ['key' => $key]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that key exists in an array/array-accessible object and its value is not empty.
+     *
+     * @param mixed $value
+     * @param string|int $key
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function notEmptyKey($value, $key, $message = null, $propertyPath = null)
+    {
+        static::keyIsset($value, $key, $message, $propertyPath);
+        static::notEmpty($value[$key], $message, $propertyPath);
+
+        return true;
+    }
+
+    /**
+     * Assert that value is not blank.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function notBlank($value, $message = null, $propertyPath = null)
+    {
+        if (false === $value || (empty($value) && '0' != $value) || (\is_string($value) && '' === \trim($value))) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is blank, but was expected to contain a value.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_NOT_BLANK, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is instance of given class-name.
+     *
+     * @param mixed $value
+     * @param string $className
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function isInstanceOf($value, $className, $message = null, $propertyPath = null)
+    {
+        if (!($value instanceof $className)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Class "%s" was expected to be instanceof of "%s" but is not.',
+                static::stringify($value),
+                $className
+            );
+
+            throw static::createException($value, $message, static::INVALID_INSTANCE_OF, $propertyPath, ['class' => $className]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is not instance of given class-name.
+     *
+     * @param mixed $value
+     * @param string $className
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function notIsInstanceOf($value, $className, $message = null, $propertyPath = null)
+    {
+        if ($value instanceof $className) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Class "%s" was not expected to be instanceof of "%s".',
+                static::stringify($value),
+                $className
+            );
+
+            throw static::createException($value, $message, static::INVALID_NOT_INSTANCE_OF, $propertyPath, ['class' => $className]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is subclass of given class-name.
+     *
+     * @param mixed $value
+     * @param string $className
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function subclassOf($value, $className, $message = null, $propertyPath = null)
+    {
+        if (!\is_subclass_of($value, $className)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Class "%s" was expected to be subclass of "%s".',
+                static::stringify($value),
+                $className
+            );
+
+            throw static::createException($value, $message, static::INVALID_SUBCLASS_OF, $propertyPath, ['class' => $className]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is in range of numbers.
+     *
+     * @param mixed $value
+     * @param mixed $minValue
+     * @param mixed $maxValue
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function range($value, $minValue, $maxValue, $message = null, $propertyPath = null)
+    {
+        static::numeric($value, $message, $propertyPath);
+
+        if ($value < $minValue || $value > $maxValue) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Number "%s" was expected to be at least "%d" and at most "%d".',
+                static::stringify($value),
+                static::stringify($minValue),
+                static::stringify($maxValue)
+            );
+
+            throw static::createException($value, $message, static::INVALID_RANGE, $propertyPath, ['min' => $minValue, 'max' => $maxValue]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that a value is at least as big as a given limit.
+     *
+     * @param mixed $value
+     * @param mixed $minValue
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function min($value, $minValue, $message = null, $propertyPath = null)
+    {
+        static::numeric($value, $message, $propertyPath);
+
+        if ($value < $minValue) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Number "%s" was expected to be at least "%s".',
+                static::stringify($value),
+                static::stringify($minValue)
+            );
+
+            throw static::createException($value, $message, static::INVALID_MIN, $propertyPath, ['min' => $minValue]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that a number is smaller as a given limit.
+     *
+     * @param mixed $value
+     * @param mixed $maxValue
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function max($value, $maxValue, $message = null, $propertyPath = null)
+    {
+        static::numeric($value, $message, $propertyPath);
+
+        if ($value > $maxValue) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Number "%s" was expected to be at most "%s".',
+                static::stringify($value),
+                static::stringify($maxValue)
+            );
+
+            throw static::createException($value, $message, static::INVALID_MAX, $propertyPath, ['max' => $maxValue]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that a file exists.
+     *
+     * @param string $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function file($value, $message = null, $propertyPath = null)
+    {
+        static::string($value, $message, $propertyPath);
+        static::notEmpty($value, $message, $propertyPath);
+
+        if (!\is_file($value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'File "%s" was expected to exist.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_FILE, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that a directory exists.
+     *
+     * @param string $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function directory($value, $message = null, $propertyPath = null)
+    {
+        static::string($value, $message, $propertyPath);
+
+        if (!\is_dir($value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Path "%s" was expected to be a directory.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_DIRECTORY, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that the value is something readable.
+     *
+     * @param string $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function readable($value, $message = null, $propertyPath = null)
+    {
+        static::string($value, $message, $propertyPath);
+
+        if (!\is_readable($value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Path "%s" was expected to be readable.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_READABLE, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that the value is something writeable.
+     *
+     * @param string $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function writeable($value, $message = null, $propertyPath = null)
+    {
+        static::string($value, $message, $propertyPath);
+
+        if (!\is_writable($value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Path "%s" was expected to be writeable.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_WRITEABLE, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is an email adress (using input_filter/FILTER_VALIDATE_EMAIL).
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function email($value, $message = null, $propertyPath = null)
+    {
+        static::string($value, $message, $propertyPath);
+
+        if (!\filter_var($value, FILTER_VALIDATE_EMAIL)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" was expected to be a valid e-mail address.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_EMAIL, $propertyPath);
+        } else {
+            $host = \substr($value, \strpos($value, '@') + 1);
+
+            // Likely not a FQDN, bug in PHP FILTER_VALIDATE_EMAIL prior to PHP 5.3.3
+            if (\version_compare(PHP_VERSION, '5.3.3', '<') && \strpos($host, '.') === false) {
+                $message = \sprintf(
+                    static::generateMessage($message) ?: 'Value "%s" was expected to be a valid e-mail address.',
+                    static::stringify($value)
+                );
+
+                throw static::createException($value, $message, static::INVALID_EMAIL, $propertyPath);
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is an URL.
+     *
+     * This code snipped was taken from the Symfony project and modified to the special demands of this method.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     *
+     * @see https://github.com/symfony/Validator/blob/master/Constraints/UrlValidator.php
+     * @see https://github.com/symfony/Validator/blob/master/Constraints/Url.php
+     */
+    public static function url($value, $message = null, $propertyPath = null)
+    {
+        static::string($value, $message, $propertyPath);
+
+        $protocols = ['http', 'https'];
+
+        $pattern = '~^
+            (%s)://                                 # protocol
+            (([\pL\pN-]+:)?([\pL\pN-]+)@)?          # basic auth
+            (
+                ([\pL\pN\pS-\.])+(\.?([\pL\pN]|xn\-\-[\pL\pN-]+)+\.?) # a domain name
+                    |                                                 # or
+                \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}                    # an IP address
+                    |                                                 # or
+                \[
+                    (?:(?:(?:(?:(?:(?:(?:[0-9a-f]{1,4})):){6})(?:(?:(?:(?:(?:[0-9a-f]{1,4})):(?:(?:[0-9a-f]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:::(?:(?:(?:[0-9a-f]{1,4})):){5})(?:(?:(?:(?:(?:[0-9a-f]{1,4})):(?:(?:[0-9a-f]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:[0-9a-f]{1,4})))?::(?:(?:(?:[0-9a-f]{1,4})):){4})(?:(?:(?:(?:(?:[0-9a-f]{1,4})):(?:(?:[0-9a-f]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:(?:[0-9a-f]{1,4})):){0,1}(?:(?:[0-9a-f]{1,4})))?::(?:(?:(?:[0-9a-f]{1,4})):){3})(?:(?:(?:(?:(?:[0-9a-f]{1,4})):(?:(?:[0-9a-f]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:(?:[0-9a-f]{1,4})):){0,2}(?:(?:[0-9a-f]{1,4})))?::(?:(?:(?:[0-9a-f]{1,4})):){2})(?:(?:(?:(?:(?:[0-9a-f]{1,4})):(?:(?:[0-9a-f]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:(?:[0-9a-f]{1,4})):){0,3}(?:(?:[0-9a-f]{1,4})))?::(?:(?:[0-9a-f]{1,4})):)(?:(?:(?:(?:(?:[0-9a-f]{1,4})):(?:(?:[0-9a-f]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:(?:[0-9a-f]{1,4})):){0,4}(?:(?:[0-9a-f]{1,4})))?::)(?:(?:(?:(?:(?:[0-9a-f]{1,4})):(?:(?:[0-9a-f]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:(?:[0-9a-f]{1,4})):){0,5}(?:(?:[0-9a-f]{1,4})))?::)(?:(?:[0-9a-f]{1,4})))|(?:(?:(?:(?:(?:(?:[0-9a-f]{1,4})):){0,6}(?:(?:[0-9a-f]{1,4})))?::))))
+                \]  # an IPv6 address
+            )
+            (:[0-9]+)?                              # a port (optional)
+            (/?|/\S+|\?\S*|\#\S*)                   # a /, nothing, a / with something, a query or a fragment
+        $~ixu';
+
+        $pattern = \sprintf($pattern, \implode('|', $protocols));
+
+        if (!\preg_match($pattern, $value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" was expected to be a valid URL starting with http or https',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_URL, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is alphanumeric.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function alnum($value, $message = null, $propertyPath = null)
+    {
+        try {
+            static::regex($value, '(^([a-zA-Z]{1}[a-zA-Z0-9]*)$)', $message, $propertyPath);
+        } catch (AssertionFailedException $e) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is not alphanumeric, starting with letters and containing only letters and numbers.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_ALNUM, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that the value is boolean True.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function true($value, $message = null, $propertyPath = null)
+    {
+        if ($value !== true) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is not TRUE.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_TRUE, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that the value is boolean False.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function false($value, $message = null, $propertyPath = null)
+    {
+        if ($value !== false) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is not FALSE.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_FALSE, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that the class exists.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function classExists($value, $message = null, $propertyPath = null)
+    {
+        if (!\class_exists($value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Class "%s" does not exist.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_CLASS, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that the interface exists.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function interfaceExists($value, $message = null, $propertyPath = null)
+    {
+        if (!\interface_exists($value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Interface "%s" does not exist.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_INTERFACE, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that the class implements the interface.
+     *
+     * @param mixed $class
+     * @param string $interfaceName
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function implementsInterface($class, $interfaceName, $message = null, $propertyPath = null)
+    {
+        $reflection = new \ReflectionClass($class);
+        if (!$reflection->implementsInterface($interfaceName)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Class "%s" does not implement interface "%s".',
+                static::stringify($class),
+                static::stringify($interfaceName)
+            );
+
+            throw static::createException($class, $message, static::INTERFACE_NOT_IMPLEMENTED, $propertyPath, ['interface' => $interfaceName]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that the given string is a valid json string.
+     *
+     * NOTICE:
+     * Since this does a json_decode to determine its validity
+     * you probably should consider, when using the variable
+     * content afterwards, just to decode and check for yourself instead
+     * of using this assertion.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function isJsonString($value, $message = null, $propertyPath = null)
+    {
+        if (null === \json_decode($value) && JSON_ERROR_NONE !== \json_last_error()) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is not a valid JSON string.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_JSON_STRING, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that the given string is a valid UUID.
+     *
+     * Uses code from {@link https://github.com/ramsey/uuid} that is MIT licensed.
+     *
+     * @param string $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function uuid($value, $message = null, $propertyPath = null)
+    {
+        $value = \str_replace(['urn:', 'uuid:', '{', '}'], '', $value);
+
+        if ($value === '00000000-0000-0000-0000-000000000000') {
+            return true;
+        }
+
+        if (!\preg_match('/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/', $value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is not a valid UUID.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_UUID, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that the given string is a valid E164 Phone Number.
+     *
+     * @see https://en.wikipedia.org/wiki/E.164
+     *
+     * @param string $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function e164($value, $message = null, $propertyPath = null)
+    {
+        if (!\preg_match('/^\+?[1-9]\d{1,14}$/', $value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" is not a valid E164.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_E164, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that the count of countable is equal to count.
+     *
+     * @param array|\Countable $countable
+     * @param int $count
+     * @param string|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function count($countable, $count, $message = null, $propertyPath = null)
+    {
+        if ($count !== \count($countable)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'List does not contain exactly "%d" elements.',
+                static::stringify($count)
+            );
+
+            throw static::createException($countable, $message, static::INVALID_COUNT, $propertyPath, ['count' => $count]);
+        }
+
+        return true;
+    }
+
+    /**
+     * static call handler to implement:
+     *  - "null or assertion" delegation
+     *  - "all" delegation.
+     *
+     * @param string $method
+     * @param array $args
+     *
+     * @return bool|mixed
+     */
+    public static function __callStatic($method, $args)
+    {
+        if (\strpos($method, 'nullOr') === 0) {
+            if (!\array_key_exists(0, $args)) {
+                throw new BadMethodCallException('Missing the first argument.');
+            }
+
+            if ($args[0] === null) {
+                return true;
+            }
+
+            $method = \substr($method, 6);
+
+            return \call_user_func_array([\get_called_class(), $method], $args);
+        }
+
+        if (\strpos($method, 'all') === 0) {
+            if (!\array_key_exists(0, $args)) {
+                throw new BadMethodCallException('Missing the first argument.');
+            }
+
+            static::isTraversable($args[0]);
+
+            $method = \substr($method, 3);
+            $values = \array_shift($args);
+            $calledClass = \get_called_class();
+
+            foreach ($values as $value) {
+                \call_user_func_array([$calledClass, $method], \array_merge([$value], $args));
+            }
+
+            return true;
+        }
+
+        throw new BadMethodCallException('No assertion Assertion#' . $method . ' exists.');
+    }
+
+    /**
+     * Determines if the values array has every choice as key and that this choice has content.
+     *
+     * @param array $values
+     * @param array $choices
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     */
+    public static function choicesNotEmpty(array $values, array $choices, $message = null, $propertyPath = null)
+    {
+        static::notEmpty($values, $message, $propertyPath);
+
+        foreach ($choices as $choice) {
+            static::notEmptyKey($values, $choice, $message, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Determines that the named method is defined in the provided object.
+     *
+     * @param string $value
+     * @param mixed $object
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws
+     */
+    public static function methodExists($value, $object, $message = null, $propertyPath = null)
+    {
+        static::isObject($object, $message, $propertyPath);
+
+        if (!\method_exists($object, $value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Expected "%s" does not exist in provided object.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_METHOD, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Determines that the provided value is an object.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     */
+    public static function isObject($value, $message = null, $propertyPath = null)
+    {
+        if (!\is_object($value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Provided "%s" is not a valid object.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_OBJECT, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Determines if the value is less than given limit.
+     *
+     * @param mixed $value
+     * @param mixed $limit
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     */
+    public static function lessThan($value, $limit, $message = null, $propertyPath = null)
+    {
+        if ($value >= $limit) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Provided "%s" is not less than "%s".',
+                static::stringify($value),
+                static::stringify($limit)
+            );
+
+            throw static::createException($value, $message, static::INVALID_LESS, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Determines if the value is less or than given limit.
+     *
+     * @param mixed $value
+     * @param mixed $limit
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     */
+    public static function lessOrEqualThan($value, $limit, $message = null, $propertyPath = null)
+    {
+        if ($value > $limit) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Provided "%s" is not less or equal than "%s".',
+                static::stringify($value),
+                static::stringify($limit)
+            );
+
+            throw static::createException($value, $message, static::INVALID_LESS_OR_EQUAL, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Determines if the value is greater than given limit.
+     *
+     * @param mixed $value
+     * @param mixed $limit
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     */
+    public static function greaterThan($value, $limit, $message = null, $propertyPath = null)
+    {
+        if ($value <= $limit) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Provided "%s" is not greater than "%s".',
+                static::stringify($value),
+                static::stringify($limit)
+            );
+
+            throw static::createException($value, $message, static::INVALID_GREATER, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Determines if the value is greater or equal than given limit.
+     *
+     * @param mixed $value
+     * @param mixed $limit
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     */
+    public static function greaterOrEqualThan($value, $limit, $message = null, $propertyPath = null)
+    {
+        if ($value < $limit) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Provided "%s" is not greater or equal than "%s".',
+                static::stringify($value),
+                static::stringify($limit)
+            );
+
+            throw static::createException($value, $message, static::INVALID_GREATER_OR_EQUAL, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that a value is greater or equal than a lower limit, and less than or equal to an upper limit.
+     *
+     * @param mixed $value
+     * @param mixed $lowerLimit
+     * @param mixed $upperLimit
+     * @param string $message
+     * @param string $propertyPath
+     *
+     * @return bool
+     */
+    public static function between($value, $lowerLimit, $upperLimit, $message = null, $propertyPath = null)
+    {
+        if ($lowerLimit > $value || $value > $upperLimit) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Provided "%s" is neither greater than or equal to "%s" nor less than or equal to "%s".',
+                static::stringify($value),
+                static::stringify($lowerLimit),
+                static::stringify($upperLimit)
+            );
+
+            throw static::createException($value, $message, static::INVALID_BETWEEN, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that a value is greater than a lower limit, and less than an upper limit.
+     *
+     * @param mixed $value
+     * @param mixed $lowerLimit
+     * @param mixed $upperLimit
+     * @param string $message
+     * @param string $propertyPath
+     *
+     * @return bool
+     */
+    public static function betweenExclusive($value, $lowerLimit, $upperLimit, $message = null, $propertyPath = null)
+    {
+        if ($lowerLimit >= $value || $value >= $upperLimit) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Provided "%s" is neither greater than "%s" nor less than "%s".',
+                static::stringify($value),
+                static::stringify($lowerLimit),
+                static::stringify($upperLimit)
+            );
+
+            throw static::createException($value, $message, static::INVALID_BETWEEN_EXCLUSIVE, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that extension is loaded.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function extensionLoaded($value, $message = null, $propertyPath = null)
+    {
+        if (!\extension_loaded($value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Extension "%s" is required.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_EXTENSION, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that date is valid and corresponds to the given format.
+     *
+     * @param string $value
+     * @param string $format supports all of the options date(), except for the following:
+     *                                           N, w, W, t, L, o, B, a, A, g, h, I, O, P, Z, c, r
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @see http://php.net/manual/function.date.php#refsect1-function.date-parameters
+     */
+    public static function date($value, $format, $message = null, $propertyPath = null)
+    {
+        static::string($value, $message, $propertyPath);
+        static::string($format, $message, $propertyPath);
+
+        $dateTime = \DateTime::createFromFormat($format, $value);
+
+        if (false === $dateTime || $value !== $dateTime->format($format)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Date "%s" is invalid or does not match format "%s".',
+                static::stringify($value),
+                static::stringify($format)
+            );
+
+            throw static::createException($value, $message, static::INVALID_DATE, $propertyPath, ['format' => $format]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that the value is an object, or a class that exists.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function objectOrClass($value, $message = null, $propertyPath = null)
+    {
+        if (!\is_object($value)) {
+            static::classExists($value, $message, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that the value is an object or class, and that the property exists.
+     *
+     * @param mixed $value
+     * @param string $property
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function propertyExists($value, $property, $message = null, $propertyPath = null)
+    {
+        static::objectOrClass($value);
+
+        if (!\property_exists($value, $property)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Class "%s" does not have property "%s".',
+                static::stringify($value),
+                static::stringify($property)
+            );
+
+            throw static::createException($value, $message, static::INVALID_PROPERTY, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that the value is an object or class, and that the properties all exist.
+     *
+     * @param mixed $value
+     * @param array $properties
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function propertiesExist($value, array $properties, $message = null, $propertyPath = null)
+    {
+        static::objectOrClass($value);
+        static::allString($properties, $message, $propertyPath);
+
+        $invalidProperties = [];
+        foreach ($properties as $property) {
+            if (!\property_exists($value, $property)) {
+                $invalidProperties[] = $property;
+            }
+        }
+
+        if ($invalidProperties) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Class "%s" does not have these properties: %s.',
+                static::stringify($value),
+                static::stringify(\implode(', ', $invalidProperties))
+            );
+
+            throw static::createException($value, $message, static::INVALID_PROPERTY, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert comparison of two versions.
+     *
+     * @param string $version1
+     * @param string $operator
+     * @param string $version2
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function version($version1, $operator, $version2, $message = null, $propertyPath = null)
+    {
+        static::notEmpty($operator, 'versionCompare operator is required and cannot be empty.');
+
+        if (\version_compare($version1, $version2, $operator) !== true) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Version "%s" is not "%s" version "%s".',
+                static::stringify($version1),
+                static::stringify($operator),
+                static::stringify($version2)
+            );
+
+            throw static::createException($version1, $message, static::INVALID_VERSION, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert on PHP version.
+     *
+     * @param string $operator
+     * @param mixed $version
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function phpVersion($operator, $version, $message = null, $propertyPath = null)
+    {
+        static::defined('PHP_VERSION');
+
+        return static::version(PHP_VERSION, $operator, $version, $message, $propertyPath);
+    }
+
+    /**
+     * Assert that extension is loaded and a specific version is installed.
+     *
+     * @param string $extension
+     * @param string $operator
+     * @param mixed $version
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function extensionVersion($extension, $operator, $version, $message = null, $propertyPath = null)
+    {
+        static::extensionLoaded($extension, $message, $propertyPath);
+
+        return static::version(\phpversion($extension), $operator, $version, $message, $propertyPath);
+    }
+
+    /**
+     * Determines that the provided value is callable.
+     *
+     * @param mixed $value
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     */
+    public static function isCallable($value, $message = null, $propertyPath = null)
+    {
+        if (!\is_callable($value)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Provided "%s" is not a callable.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_CALLABLE, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that the provided value is valid according to a callback.
+     *
+     * If the callback returns `false` the assertion will fail.
+     *
+     * @param mixed $value
+     * @param callable $callback
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     */
+    public static function satisfy($value, $callback, $message = null, $propertyPath = null)
+    {
+        static::isCallable($callback);
+
+        if (\call_user_func($callback, $value) === false) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Provided "%s" is invalid according to custom rule.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_SATISFY, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is an IPv4 or IPv6 address
+     * (using input_filter/FILTER_VALIDATE_IP).
+     *
+     * @param string $value
+     * @param null|int $flag
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @see http://php.net/manual/filter.filters.flags.php
+     */
+    public static function ip($value, $flag = null, $message = null, $propertyPath = null)
+    {
+        static::string($value, $message, $propertyPath);
+        if (!\filter_var($value, FILTER_VALIDATE_IP, $flag)) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Value "%s" was expected to be a valid IP address.',
+                static::stringify($value)
+            );
+            throw static::createException($value, $message, static::INVALID_IP, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that value is an IPv4 address
+     * (using input_filter/FILTER_VALIDATE_IP).
+     *
+     * @param string $value
+     * @param null|int $flag
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @see http://php.net/manual/filter.filters.flags.php
+     */
+    public static function ipv4($value, $flag = null, $message = null, $propertyPath = null)
+    {
+        static::ip($value, $flag | FILTER_FLAG_IPV4, static::generateMessage($message) ?: 'Value "%s" was expected to be a valid IPv4 address.', $propertyPath);
+
+        return true;
+    }
+
+    /**
+     * Assert that value is an IPv6 address
+     * (using input_filter/FILTER_VALIDATE_IP).
+     *
+     * @param string $value
+     * @param null|int $flag
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @see http://php.net/manual/filter.filters.flags.php
+     */
+    public static function ipv6($value, $flag = null, $message = null, $propertyPath = null)
+    {
+        static::ip($value, $flag | FILTER_FLAG_IPV6, static::generateMessage($message) ?: 'Value "%s" was expected to be a valid IPv6 address.', $propertyPath);
+
+        return true;
+    }
+
+    /**
+     * Make a string version of a value.
+     *
+     * @param mixed $value
+     *
+     * @return string
+     */
+    protected static function stringify($value)
+    {
+        $result = \gettype($value);
+
+        if (\is_bool($value)) {
+            $result = $value ? '<TRUE>' : '<FALSE>';
+        }
+
+        if (\is_scalar($value)) {
+            $val = (string)$value;
+
+            if (\strlen($val) > 100) {
+                $val = \substr($val, 0, 97) . '...';
+            }
+
+            $result = $val;
+        }
+
+        if (\is_array($value)) {
+            $result = '<ARRAY>';
+        }
+
+        if (\is_object($value)) {
+            $result = \get_class($value);
+        }
+
+        if (\is_resource($value)) {
+            $result = \get_resource_type($value);
+        }
+
+        if ($value === null) {
+            $result = '<NULL>';
+        }
+
+        return $result;
+    }
+
+    /**
+     * Assert that a constant is defined.
+     *
+     * @param mixed $constant
+     * @param string|callable|null $message
+     * @param string|null $propertyPath
+     *
+     * @return bool
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function defined($constant, $message = null, $propertyPath = null)
+    {
+        if (!\defined($constant)) {
+            $message = \sprintf(static::generateMessage($message) ?: 'Value "%s" expected to be a defined constant.', $constant);
+
+            throw static::createException($constant, $message, static::INVALID_CONSTANT, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Generate the message.
+     *
+     * @param string|callable|null $message
+     *
+     * @return string|null
+     */
+    protected static function generateMessage($message = null)
+    {
+        if (\is_callable($message)) {
+            $traces = \debug_backtrace(0);
+
+            $parameters = [];
+
+            $reflection = new \ReflectionClass($traces[1]['class']);
+            $method = $reflection->getMethod($traces[1]['function']);
+            foreach ($method->getParameters() as $index => $parameter) {
+                if ($parameter->getName() !== 'message') {
+                    $parameters[$parameter->getName()] = \array_key_exists($index, $traces[1]['args'])
+                        ? $traces[1]['args'][$index]
+                        : $parameter->getDefaultValue();
+                }
+            }
+
+            $parameters['::assertion'] = \sprintf('%s%s%s', $traces[1]['class'], $traces[1]['type'], $traces[1]['function']);
+
+            $message = \call_user_func_array($message, [$parameters]);
+        }
+
+        return \is_null($message) ? null : (string)$message;
+    }
+}

--- a/libs/TLS/Assert/AssertionChain.php
+++ b/libs/TLS/Assert/AssertionChain.php
@@ -1,0 +1,229 @@
+<?php
+
+/**
+ * Assert
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace Assert;
+
+use LogicException;
+use ReflectionClass;
+
+/**
+ * Chaining builder for assertions.
+ *
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * @method AssertionChain alnum(string | callable $message = null, string $propertyPath = null) Assert that value is alphanumeric.
+ * @method AssertionChain between(mixed $lowerLimit, mixed $upperLimit, string $message = null, string $propertyPath = null) Assert that a value is greater or equal than a lower limit, and less than or equal to an upper limit.
+ * @method AssertionChain betweenExclusive(mixed $lowerLimit, mixed $upperLimit, string $message = null, string $propertyPath = null) Assert that a value is greater than a lower limit, and less than an upper limit.
+ * @method AssertionChain betweenLength(int $minLength, int $maxLength, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string length is between min, max lengths.
+ * @method AssertionChain boolean(string | callable $message = null, string $propertyPath = null) Assert that value is php boolean.
+ * @method AssertionChain choice(array $choices, string | callable $message = null, string $propertyPath = null) Assert that value is in array of choices.
+ * @method AssertionChain choicesNotEmpty(array $choices, string | callable $message = null, string $propertyPath = null) Determines if the values array has every choice as key and that this choice has content.
+ * @method AssertionChain classExists(string | callable $message = null, string $propertyPath = null) Assert that the class exists.
+ * @method AssertionChain contains(string $needle, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string contains a sequence of chars.
+ * @method AssertionChain count(array | \Countable $count, string $message = null, string $propertyPath = null) Assert that the count of countable is equal to count.
+ * @method AssertionChain date(string $format, string | callable $message = null, string $propertyPath = null) Assert that date is valid and corresponds to the given format.
+ * @method AssertionChain defined(string | callable $message = null, string $propertyPath = null) Assert that a constant is defined.
+ * @method AssertionChain digit(string | callable $message = null, string $propertyPath = null) Validates if an integer or integerish is a digit.
+ * @method AssertionChain directory(string | callable $message = null, string $propertyPath = null) Assert that a directory exists.
+ * @method AssertionChain e164(string | callable $message = null, string $propertyPath = null) Assert that the given string is a valid E164 Phone Number.
+ * @method AssertionChain email(string | callable $message = null, string $propertyPath = null) Assert that value is an email adress (using input_filter/FILTER_VALIDATE_EMAIL).
+ * @method AssertionChain endsWith(string $needle, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string ends with a sequence of chars.
+ * @method AssertionChain eq(mixed $value2, string | callable $message = null, string $propertyPath = null) Assert that two values are equal (using ==).
+ * @method AssertionChain extensionLoaded(string | callable $message = null, string $propertyPath = null) Assert that extension is loaded.
+ * @method AssertionChain extensionVersion(string $operator, mixed $version, string | callable $message = null, string $propertyPath = null) Assert that extension is loaded and a specific version is installed.
+ * @method AssertionChain false(string | callable $message = null, string $propertyPath = null) Assert that the value is boolean False.
+ * @method AssertionChain file(string | callable $message = null, string $propertyPath = null) Assert that a file exists.
+ * @method AssertionChain float(string | callable $message = null, string $propertyPath = null) Assert that value is a php float.
+ * @method AssertionChain greaterOrEqualThan(mixed $limit, string | callable $message = null, string $propertyPath = null) Determines if the value is greater or equal than given limit.
+ * @method AssertionChain greaterThan(mixed $limit, string | callable $message = null, string $propertyPath = null) Determines if the value is greater than given limit.
+ * @method AssertionChain implementsInterface(string $interfaceName, string | callable $message = null, string $propertyPath = null) Assert that the class implements the interface.
+ * @method AssertionChain inArray(array $choices, string | callable $message = null, string $propertyPath = null) Assert that value is in array of choices. This is an alias of Assertion::choice().
+ * @method AssertionChain integer(string | callable $message = null, string $propertyPath = null) Assert that value is a php integer.
+ * @method AssertionChain integerish(string | callable $message = null, string $propertyPath = null) Assert that value is a php integer'ish.
+ * @method AssertionChain interfaceExists(string | callable $message = null, string $propertyPath = null) Assert that the interface exists.
+ * @method AssertionChain ip(int $flag = null, string | callable $message = null, string $propertyPath = null) Assert that value is an IPv4 or IPv6 address.
+ * @method AssertionChain ipv4(int $flag = null, string | callable $message = null, string $propertyPath = null) Assert that value is an IPv4 address.
+ * @method AssertionChain ipv6(int $flag = null, string | callable $message = null, string $propertyPath = null) Assert that value is an IPv6 address.
+ * @method AssertionChain isArray(string | callable $message = null, string $propertyPath = null) Assert that value is an array.
+ * @method AssertionChain isArrayAccessible(string | callable $message = null, string $propertyPath = null) Assert that value is an array or an array-accessible object.
+ * @method AssertionChain isCallable(string | callable $message = null, string $propertyPath = null) Determines that the provided value is callable.
+ * @method AssertionChain isInstanceOf(string $className, string | callable $message = null, string $propertyPath = null) Assert that value is instance of given class-name.
+ * @method AssertionChain isJsonString(string | callable $message = null, string $propertyPath = null) Assert that the given string is a valid json string.
+ * @method AssertionChain isObject(string | callable $message = null, string $propertyPath = null) Determines that the provided value is an object.
+ * @method AssertionChain isResource(string | callable $message = null, string $propertyPath = null) Assert that value is a resource.
+ * @method AssertionChain isTraversable(string | callable $message = null, string $propertyPath = null) Assert that value is an array or a traversable object.
+ * @method AssertionChain keyExists(string | int $key, string | callable $message = null, string $propertyPath = null) Assert that key exists in an array.
+ * @method AssertionChain keyIsset(string | int $key, string | callable $message = null, string $propertyPath = null) Assert that key exists in an array/array-accessible object using isset().
+ * @method AssertionChain keyNotExists(string | int $key, string | callable $message = null, string $propertyPath = null) Assert that key does not exist in an array.
+ * @method AssertionChain length(int $length, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string has a given length.
+ * @method AssertionChain lessOrEqualThan(mixed $limit, string | callable $message = null, string $propertyPath = null) Determines if the value is less or than given limit.
+ * @method AssertionChain lessThan(mixed $limit, string | callable $message = null, string $propertyPath = null) Determines if the value is less than given limit.
+ * @method AssertionChain max(mixed $maxValue, string | callable $message = null, string $propertyPath = null) Assert that a number is smaller as a given limit.
+ * @method AssertionChain maxLength(int $maxLength, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string value is not longer than $maxLength chars.
+ * @method AssertionChain methodExists(mixed $object, string | callable $message = null, string $propertyPath = null) Determines that the named method is defined in the provided object.
+ * @method AssertionChain min(mixed $minValue, string | callable $message = null, string $propertyPath = null) Assert that a value is at least as big as a given limit.
+ * @method AssertionChain minLength(int $minLength, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that a string is at least $minLength chars long.
+ * @method AssertionChain noContent(string | callable $message = null, string $propertyPath = null) Assert that value is empty.
+ * @method AssertionChain notBlank(string | callable $message = null, string $propertyPath = null) Assert that value is not blank.
+ * @method AssertionChain notEmpty(string | callable $message = null, string $propertyPath = null) Assert that value is not empty.
+ * @method AssertionChain notEmptyKey(string | int $key, string | callable $message = null, string $propertyPath = null) Assert that key exists in an array/array-accessible object and its value is not empty.
+ * @method AssertionChain notEq(mixed $value2, string | callable $message = null, string $propertyPath = null) Assert that two values are not equal (using ==).
+ * @method AssertionChain notInArray(array $choices, string | callable $message = null, string $propertyPath = null) Assert that value is not in array of choices.
+ * @method AssertionChain notIsInstanceOf(string $className, string | callable $message = null, string $propertyPath = null) Assert that value is not instance of given class-name.
+ * @method AssertionChain notNull(string | callable $message = null, string $propertyPath = null) Assert that value is not null.
+ * @method AssertionChain notSame(mixed $value2, string | callable $message = null, string $propertyPath = null) Assert that two values are not the same (using ===).
+ * @method AssertionChain null(string | callable $message = null, string $propertyPath = null) Assert that value is null.
+ * @method AssertionChain numeric(string | callable $message = null, string $propertyPath = null) Assert that value is numeric.
+ * @method AssertionChain objectOrClass(string | callable $message = null, string $propertyPath = null) Assert that the value is an object, or a class that exists.
+ * @method AssertionChain phpVersion(mixed $version, string | callable $message = null, string $propertyPath = null) Assert on PHP version.
+ * @method AssertionChain propertiesExist(array $properties, string | callable $message = null, string $propertyPath = null) Assert that the value is an object or class, and that the properties all exist.
+ * @method AssertionChain propertyExists(string $property, string | callable $message = null, string $propertyPath = null) Assert that the value is an object or class, and that the property exists.
+ * @method AssertionChain range(mixed $minValue, mixed $maxValue, string | callable $message = null, string $propertyPath = null) Assert that value is in range of numbers.
+ * @method AssertionChain readable(string | callable $message = null, string $propertyPath = null) Assert that the value is something readable.
+ * @method AssertionChain regex(string $pattern, string | callable $message = null, string $propertyPath = null) Assert that value matches a regex.
+ * @method AssertionChain same(mixed $value2, string | callable $message = null, string $propertyPath = null) Assert that two values are the same (using ===).
+ * @method AssertionChain satisfy(callable $callback, string | callable $message = null, string $propertyPath = null) Assert that the provided value is valid according to a callback.
+ * @method AssertionChain scalar(string | callable $message = null, string $propertyPath = null) Assert that value is a PHP scalar.
+ * @method AssertionChain startsWith(string $needle, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string starts with a sequence of chars.
+ * @method AssertionChain string(string | callable $message = null, string $propertyPath = null) Assert that value is a string.
+ * @method AssertionChain subclassOf(string $className, string | callable $message = null, string $propertyPath = null) Assert that value is subclass of given class-name.
+ * @method AssertionChain true(string | callable $message = null, string $propertyPath = null) Assert that the value is boolean True.
+ * @method AssertionChain url(string | callable $message = null, string $propertyPath = null) Assert that value is an URL.
+ * @method AssertionChain uuid(string | callable $message = null, string $propertyPath = null) Assert that the given string is a valid UUID.
+ * @method AssertionChain version(string $operator, string $version2, string | callable $message = null, string $propertyPath = null) Assert comparison of two versions.
+ * @method AssertionChain writeable(string | callable $message = null, string $propertyPath = null) Assert that the value is something writeable.
+ */
+class AssertionChain
+{
+    private $value;
+    private $defaultMessage;
+    private $defaultPropertyPath;
+
+    /**
+     * Return each assertion as always valid.
+     *
+     * @var bool
+     */
+    private $alwaysValid = false;
+
+    /**
+     * Perform assertion on every element of array or traversable.
+     *
+     * @var bool
+     */
+    private $all = false;
+
+    /** @var string|Assertion Class to use for assertion calls */
+    private $assertionClassName = 'Assert\Assertion';
+
+    public function __construct($value, $defaultMessage = null, $defaultPropertyPath = null)
+    {
+        $this->value = $value;
+        $this->defaultMessage = $defaultMessage;
+        $this->defaultPropertyPath = $defaultPropertyPath;
+    }
+
+    /**
+     * Call assertion on the current value in the chain.
+     *
+     * @param string $methodName
+     * @param array $args
+     *
+     * @return \Assert\AssertionChain
+     */
+    public function __call($methodName, $args)
+    {
+        if ($this->alwaysValid === true) {
+            return $this;
+        }
+
+        if (!\method_exists($this->assertionClassName, $methodName)) {
+            throw new \RuntimeException("Assertion '" . $methodName . "' does not exist.");
+        }
+
+        $reflClass = new ReflectionClass($this->assertionClassName);
+        $method = $reflClass->getMethod($methodName);
+
+        \array_unshift($args, $this->value);
+        $params = $method->getParameters();
+
+        foreach ($params as $idx => $param) {
+            if (isset($args[$idx])) {
+                continue;
+            }
+
+            if ($param->getName() == 'message') {
+                $args[$idx] = $this->defaultMessage;
+            }
+
+            if ($param->getName() == 'propertyPath') {
+                $args[$idx] = $this->defaultPropertyPath;
+            }
+        }
+
+        if ($this->all) {
+            $methodName = 'all' . $methodName;
+        }
+
+        \call_user_func_array([$this->assertionClassName, $methodName], $args);
+
+        return $this;
+    }
+
+    /**
+     * Switch chain into validation mode for an array of values.
+     *
+     * @return \Assert\AssertionChain
+     */
+    public function all()
+    {
+        $this->all = true;
+
+        return $this;
+    }
+
+    /**
+     * Switch chain into mode allowing nulls, ignoring further assertions.
+     *
+     * @return \Assert\AssertionChain
+     */
+    public function nullOr()
+    {
+        if ($this->value === null) {
+            $this->alwaysValid = true;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string $className
+     *
+     * @return $this
+     */
+    public function setAssertionClassName($className)
+    {
+        if (!\is_string($className)) {
+            throw new LogicException('Exception class name must be passed as a string');
+        }
+
+        if ($className !== 'Assert\Assertion' && !\is_subclass_of($className, 'Assert\Assertion')) {
+            throw new LogicException($className . ' is not (a subclass of) Assert\Assertion');
+        }
+
+        $this->assertionClassName = $className;
+
+        return $this;
+    }
+}

--- a/libs/TLS/Assert/AssertionFailedException.php
+++ b/libs/TLS/Assert/AssertionFailedException.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Assert
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace Assert;
+
+interface AssertionFailedException
+{
+    public function getPropertyPath();
+
+    public function getValue();
+
+    public function getConstraints();
+}

--- a/libs/TLS/Assert/InvalidArgumentException.php
+++ b/libs/TLS/Assert/InvalidArgumentException.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Assert
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace Assert;
+
+class InvalidArgumentException extends \InvalidArgumentException implements AssertionFailedException
+{
+    private $propertyPath;
+    private $value;
+    private $constraints;
+
+    public function __construct($message, $code, $propertyPath, $value, array $constraints = [])
+    {
+        parent::__construct($message, $code);
+
+        $this->propertyPath = $propertyPath;
+        $this->value = $value;
+        $this->constraints = $constraints;
+    }
+
+    /**
+     * User controlled way to define a sub-property causing
+     * the failure of a currently asserted objects.
+     *
+     * Useful to transport information about the nature of the error
+     * back to higher layers.
+     *
+     * @return string
+     */
+    public function getPropertyPath()
+    {
+        return $this->propertyPath;
+    }
+
+    /**
+     * Get the value that caused the assertion to fail.
+     *
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Get the constraints that applied to the failed assertion.
+     *
+     * @return array
+     */
+    public function getConstraints()
+    {
+        return $this->constraints;
+    }
+}

--- a/libs/TLS/Assert/LICENSE
+++ b/libs/TLS/Assert/LICENSE
@@ -1,0 +1,11 @@
+Copyright (c) 2011-2013, Benjamin Eberlei
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.

--- a/libs/TLS/Assert/LazyAssertion.php
+++ b/libs/TLS/Assert/LazyAssertion.php
@@ -1,0 +1,191 @@
+<?php
+
+/**
+ * Assert
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace Assert;
+
+use LogicException;
+
+/**
+ * Chaining builder for lazy assertions.
+ *
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * @method LazyAssertion alnum(string | callable $message = null, string $propertyPath = null) Assert that value is alphanumeric.
+ * @method LazyAssertion between(mixed $lowerLimit, mixed $upperLimit, string $message = null, string $propertyPath = null) Assert that a value is greater or equal than a lower limit, and less than or equal to an upper limit.
+ * @method LazyAssertion betweenExclusive(mixed $lowerLimit, mixed $upperLimit, string $message = null, string $propertyPath = null) Assert that a value is greater than a lower limit, and less than an upper limit.
+ * @method LazyAssertion betweenLength(int $minLength, int $maxLength, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string length is between min, max lengths.
+ * @method LazyAssertion boolean(string | callable $message = null, string $propertyPath = null) Assert that value is php boolean.
+ * @method LazyAssertion choice(array $choices, string | callable $message = null, string $propertyPath = null) Assert that value is in array of choices.
+ * @method LazyAssertion choicesNotEmpty(array $choices, string | callable $message = null, string $propertyPath = null) Determines if the values array has every choice as key and that this choice has content.
+ * @method LazyAssertion classExists(string | callable $message = null, string $propertyPath = null) Assert that the class exists.
+ * @method LazyAssertion contains(string $needle, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string contains a sequence of chars.
+ * @method LazyAssertion count(array | \Countable $count, string $message = null, string $propertyPath = null) Assert that the count of countable is equal to count.
+ * @method LazyAssertion date(string $format, string | callable $message = null, string $propertyPath = null) Assert that date is valid and corresponds to the given format.
+ * @method LazyAssertion defined(string | callable $message = null, string $propertyPath = null) Assert that a constant is defined.
+ * @method LazyAssertion digit(string | callable $message = null, string $propertyPath = null) Validates if an integer or integerish is a digit.
+ * @method LazyAssertion directory(string | callable $message = null, string $propertyPath = null) Assert that a directory exists.
+ * @method LazyAssertion e164(string | callable $message = null, string $propertyPath = null) Assert that the given string is a valid E164 Phone Number.
+ * @method LazyAssertion email(string | callable $message = null, string $propertyPath = null) Assert that value is an email adress (using input_filter/FILTER_VALIDATE_EMAIL).
+ * @method LazyAssertion endsWith(string $needle, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string ends with a sequence of chars.
+ * @method LazyAssertion eq(mixed $value2, string | callable $message = null, string $propertyPath = null) Assert that two values are equal (using ==).
+ * @method LazyAssertion extensionLoaded(string | callable $message = null, string $propertyPath = null) Assert that extension is loaded.
+ * @method LazyAssertion extensionVersion(string $operator, mixed $version, string | callable $message = null, string $propertyPath = null) Assert that extension is loaded and a specific version is installed.
+ * @method LazyAssertion false(string | callable $message = null, string $propertyPath = null) Assert that the value is boolean False.
+ * @method LazyAssertion file(string | callable $message = null, string $propertyPath = null) Assert that a file exists.
+ * @method LazyAssertion float(string | callable $message = null, string $propertyPath = null) Assert that value is a php float.
+ * @method LazyAssertion greaterOrEqualThan(mixed $limit, string | callable $message = null, string $propertyPath = null) Determines if the value is greater or equal than given limit.
+ * @method LazyAssertion greaterThan(mixed $limit, string | callable $message = null, string $propertyPath = null) Determines if the value is greater than given limit.
+ * @method LazyAssertion implementsInterface(string $interfaceName, string | callable $message = null, string $propertyPath = null) Assert that the class implements the interface.
+ * @method LazyAssertion inArray(array $choices, string | callable $message = null, string $propertyPath = null) Assert that value is in array of choices. This is an alias of Assertion::choice().
+ * @method LazyAssertion integer(string | callable $message = null, string $propertyPath = null) Assert that value is a php integer.
+ * @method LazyAssertion integerish(string | callable $message = null, string $propertyPath = null) Assert that value is a php integer'ish.
+ * @method LazyAssertion interfaceExists(string | callable $message = null, string $propertyPath = null) Assert that the interface exists.
+ * @method LazyAssertion ip(int $flag = null, string | callable $message = null, string $propertyPath = null) Assert that value is an IPv4 or IPv6 address.
+ * @method LazyAssertion ipv4(int $flag = null, string | callable $message = null, string $propertyPath = null) Assert that value is an IPv4 address.
+ * @method LazyAssertion ipv6(int $flag = null, string | callable $message = null, string $propertyPath = null) Assert that value is an IPv6 address.
+ * @method LazyAssertion isArray(string | callable $message = null, string $propertyPath = null) Assert that value is an array.
+ * @method LazyAssertion isArrayAccessible(string | callable $message = null, string $propertyPath = null) Assert that value is an array or an array-accessible object.
+ * @method LazyAssertion isCallable(string | callable $message = null, string $propertyPath = null) Determines that the provided value is callable.
+ * @method LazyAssertion isInstanceOf(string $className, string | callable $message = null, string $propertyPath = null) Assert that value is instance of given class-name.
+ * @method LazyAssertion isJsonString(string | callable $message = null, string $propertyPath = null) Assert that the given string is a valid json string.
+ * @method LazyAssertion isObject(string | callable $message = null, string $propertyPath = null) Determines that the provided value is an object.
+ * @method LazyAssertion isResource(string | callable $message = null, string $propertyPath = null) Assert that value is a resource.
+ * @method LazyAssertion isTraversable(string | callable $message = null, string $propertyPath = null) Assert that value is an array or a traversable object.
+ * @method LazyAssertion keyExists(string | int $key, string | callable $message = null, string $propertyPath = null) Assert that key exists in an array.
+ * @method LazyAssertion keyIsset(string | int $key, string | callable $message = null, string $propertyPath = null) Assert that key exists in an array/array-accessible object using isset().
+ * @method LazyAssertion keyNotExists(string | int $key, string | callable $message = null, string $propertyPath = null) Assert that key does not exist in an array.
+ * @method LazyAssertion length(int $length, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string has a given length.
+ * @method LazyAssertion lessOrEqualThan(mixed $limit, string | callable $message = null, string $propertyPath = null) Determines if the value is less or than given limit.
+ * @method LazyAssertion lessThan(mixed $limit, string | callable $message = null, string $propertyPath = null) Determines if the value is less than given limit.
+ * @method LazyAssertion max(mixed $maxValue, string | callable $message = null, string $propertyPath = null) Assert that a number is smaller as a given limit.
+ * @method LazyAssertion maxLength(int $maxLength, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string value is not longer than $maxLength chars.
+ * @method LazyAssertion methodExists(mixed $object, string | callable $message = null, string $propertyPath = null) Determines that the named method is defined in the provided object.
+ * @method LazyAssertion min(mixed $minValue, string | callable $message = null, string $propertyPath = null) Assert that a value is at least as big as a given limit.
+ * @method LazyAssertion minLength(int $minLength, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that a string is at least $minLength chars long.
+ * @method LazyAssertion noContent(string | callable $message = null, string $propertyPath = null) Assert that value is empty.
+ * @method LazyAssertion notBlank(string | callable $message = null, string $propertyPath = null) Assert that value is not blank.
+ * @method LazyAssertion notEmpty(string | callable $message = null, string $propertyPath = null) Assert that value is not empty.
+ * @method LazyAssertion notEmptyKey(string | int $key, string | callable $message = null, string $propertyPath = null) Assert that key exists in an array/array-accessible object and its value is not empty.
+ * @method LazyAssertion notEq(mixed $value2, string | callable $message = null, string $propertyPath = null) Assert that two values are not equal (using ==).
+ * @method LazyAssertion notInArray(array $choices, string | callable $message = null, string $propertyPath = null) Assert that value is not in array of choices.
+ * @method LazyAssertion notIsInstanceOf(string $className, string | callable $message = null, string $propertyPath = null) Assert that value is not instance of given class-name.
+ * @method LazyAssertion notNull(string | callable $message = null, string $propertyPath = null) Assert that value is not null.
+ * @method LazyAssertion notSame(mixed $value2, string | callable $message = null, string $propertyPath = null) Assert that two values are not the same (using ===).
+ * @method LazyAssertion null(string | callable $message = null, string $propertyPath = null) Assert that value is null.
+ * @method LazyAssertion numeric(string | callable $message = null, string $propertyPath = null) Assert that value is numeric.
+ * @method LazyAssertion objectOrClass(string | callable $message = null, string $propertyPath = null) Assert that the value is an object, or a class that exists.
+ * @method LazyAssertion phpVersion(mixed $version, string | callable $message = null, string $propertyPath = null) Assert on PHP version.
+ * @method LazyAssertion propertiesExist(array $properties, string | callable $message = null, string $propertyPath = null) Assert that the value is an object or class, and that the properties all exist.
+ * @method LazyAssertion propertyExists(string $property, string | callable $message = null, string $propertyPath = null) Assert that the value is an object or class, and that the property exists.
+ * @method LazyAssertion range(mixed $minValue, mixed $maxValue, string | callable $message = null, string $propertyPath = null) Assert that value is in range of numbers.
+ * @method LazyAssertion readable(string | callable $message = null, string $propertyPath = null) Assert that the value is something readable.
+ * @method LazyAssertion regex(string $pattern, string | callable $message = null, string $propertyPath = null) Assert that value matches a regex.
+ * @method LazyAssertion same(mixed $value2, string | callable $message = null, string $propertyPath = null) Assert that two values are the same (using ===).
+ * @method LazyAssertion satisfy(callable $callback, string | callable $message = null, string $propertyPath = null) Assert that the provided value is valid according to a callback.
+ * @method LazyAssertion scalar(string | callable $message = null, string $propertyPath = null) Assert that value is a PHP scalar.
+ * @method LazyAssertion startsWith(string $needle, string | callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string starts with a sequence of chars.
+ * @method LazyAssertion string(string | callable $message = null, string $propertyPath = null) Assert that value is a string.
+ * @method LazyAssertion subclassOf(string $className, string | callable $message = null, string $propertyPath = null) Assert that value is subclass of given class-name.
+ * @method LazyAssertion true(string | callable $message = null, string $propertyPath = null) Assert that the value is boolean True.
+ * @method LazyAssertion url(string | callable $message = null, string $propertyPath = null) Assert that value is an URL.
+ * @method LazyAssertion uuid(string | callable $message = null, string $propertyPath = null) Assert that the given string is a valid UUID.
+ * @method LazyAssertion version(string $operator, string $version2, string | callable $message = null, string $propertyPath = null) Assert comparison of two versions.
+ * @method LazyAssertion writeable(string | callable $message = null, string $propertyPath = null) Assert that the value is something writeable.
+ * @method LazyAssertion all() Switch chain into validation mode for an array of values.
+ * @method LazyAssertion nullOr() Switch chain into mode allowing nulls, ignoring further assertions.
+ */
+class LazyAssertion
+{
+    private $currentChainFailed = false;
+    private $alwaysTryAll = false;
+    private $thisChainTryAll = false;
+    private $currentChain;
+    private $errors = [];
+
+    /** @var string|LazyAssertionException The class to use for exceptions */
+    private $exceptionClass = 'Assert\LazyAssertionException';
+
+    public function that($value, $propertyPath, $defaultMessage = null)
+    {
+        $this->currentChainFailed = false;
+        $this->thisChainTryAll = false;
+        $this->currentChain = Assert::that($value, $defaultMessage, $propertyPath);
+
+        return $this;
+    }
+
+    public function tryAll()
+    {
+        if (!$this->currentChain) {
+            $this->alwaysTryAll = true;
+        }
+
+        $this->thisChainTryAll = true;
+
+        return $this;
+    }
+
+    public function __call($method, $args)
+    {
+        if ($this->alwaysTryAll === false
+            && $this->thisChainTryAll === false
+            && $this->currentChainFailed === true
+        ) {
+            return $this;
+        }
+
+        try {
+            \call_user_func_array([$this->currentChain, $method], $args);
+        } catch (AssertionFailedException $e) {
+            $this->errors[] = $e;
+            $this->currentChainFailed = true;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @throws \Assert\LazyAssertionException
+     *
+     * @return bool
+     */
+    public function verifyNow()
+    {
+        if ($this->errors) {
+            throw \call_user_func([$this->exceptionClass, 'fromErrors'], $this->errors);
+        }
+
+        return true;
+    }
+
+    /**
+     * @param string $className
+     *
+     * @return $this
+     */
+    public function setExceptionClass($className)
+    {
+        if (!\is_string($className)) {
+            throw new LogicException('Exception class name must be passed as a string');
+        }
+
+        if ($className !== 'Assert\LazyAssertionException' && !\is_subclass_of($className, 'Assert\LazyAssertionException')) {
+            throw new LogicException($className . ' is not (a subclass of) Assert\LazyAssertionException');
+        }
+
+        $this->exceptionClass = $className;
+
+        return $this;
+    }
+}

--- a/libs/TLS/Assert/LazyAssertionException.php
+++ b/libs/TLS/Assert/LazyAssertionException.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Assert
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace Assert;
+
+class LazyAssertionException extends InvalidArgumentException
+{
+    /**
+     * @var InvalidArgumentException[]
+     */
+    private $errors = [];
+
+    /**
+     * @param InvalidArgumentException[] $errors
+     *
+     * @return self
+     */
+    public static function fromErrors(array $errors)
+    {
+        $message = \sprintf('The following %d assertions failed:', \count($errors)) . "\n";
+
+        $i = 1;
+        foreach ($errors as $error) {
+            $message .= \sprintf("%d) %s: %s\n", $i++, $error->getPropertyPath(), $error->getMessage());
+        }
+
+        return new static($message, $errors);
+    }
+
+    public function __construct($message, array $errors)
+    {
+        parent::__construct($message, 0, null, null);
+
+        $this->errors = $errors;
+    }
+
+    public function getErrorExceptions()
+    {
+        return $this->errors;
+    }
+}

--- a/libs/TLS/Assert/functions.php
+++ b/libs/TLS/Assert/functions.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Assert
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace Assert;
+
+if (!\function_exists(__NAMESPACE__ . '\that')) {
+    /**
+     * Start validation on a value, returns {@link AssertionChain}.
+     *
+     * The invocation of this method starts an assertion chain
+     * that is happening on the passed value.
+     *
+     * @example
+     *
+     *  \Assert\that($value)->notEmpty()->integer();
+     *  \Assert\that($value)->nullOr()->string()->startsWith("Foo");
+     *
+     * The assertion chain can be stateful, that means be careful when you reuse
+     * it. You should never pass around the chain.
+     *
+     * @param mixed $value
+     * @param string $defaultMessage
+     * @param string $defaultPropertyPath
+     *
+     * @return \Assert\AssertionChain
+     *
+     * @deprecated In favour of Assert::that($value, $defaultMessage = null, $defaultPropertyPath = null)
+     */
+    function that($value, $defaultMessage = null, $defaultPropertyPath = null)
+    {
+        return Assert::that($value, $defaultMessage, $defaultPropertyPath);
+    }
+}
+
+if (!\function_exists(__NAMESPACE__ . '\thatAll')) {
+    /**
+     * Start validation on a set of values, returns {@link AssertionChain}.
+     *
+     * @param mixed $values
+     * @param string $defaultMessage
+     * @param string $defaultPropertyPath
+     *
+     * @return \Assert\AssertionChain
+     *
+     * @deprecated In favour of Assert::thatAll($values, $defaultMessage = null, $defaultPropertyPath = null)
+     */
+    function thatAll($values, $defaultMessage = null, $defaultPropertyPath = null)
+    {
+        return Assert::that($values, $defaultMessage, $defaultPropertyPath)->all();
+    }
+}
+
+if (!\function_exists(__NAMESPACE__ . '\thatNullOr')) {
+    /**
+     * Start validation and allow NULL, returns {@link AssertionChain}.
+     *
+     * @param mixed $value
+     * @param string $defaultMessage
+     * @param string $defaultPropertyPath
+     *
+     * @return \Assert\AssertionChain
+     *
+     * @deprecated In favour of Assert::thatNullOr($value, $defaultMessage = null, $defaultPropertyPath = null)
+     */
+    function thatNullOr($value, $defaultMessage = null, $defaultPropertyPath = null)
+    {
+        return Assert::that($value, $defaultMessage, $defaultPropertyPath)->nullOr();
+    }
+}
+
+if (!\function_exists(__NAMESPACE__ . '\lazy')) {
+    /**
+     * Create a lazy assertion object.
+     *
+     * @return \Assert\LazyAssertion
+     *
+     * @deprecated In favour of Assert::lazy()
+     */
+    function lazy()
+    {
+        return Assert::lazy();
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Crypto/EcDH/EcDH.php
+++ b/libs/TLS/Mdanter/Ecc/Crypto/EcDH/EcDH.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Mdanter\Ecc\Crypto\EcDH;
+
+/**
+ * *********************************************************************
+ * Copyright (C) 2012 Matyas Danter
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * ***********************************************************************
+ */
+
+use Mdanter\Ecc\Crypto\Key\PrivateKeyInterface;
+use Mdanter\Ecc\Crypto\Key\PublicKey;
+use Mdanter\Ecc\Crypto\Key\PublicKeyInterface;
+use Mdanter\Ecc\Math\GmpMathInterface;
+use Mdanter\Ecc\Primitives\PointInterface;
+
+/**
+ * This class is the implementation of ECDH.
+ * EcDH is safe key exchange and achieves
+ * that a key is transported securely between two parties.
+ * The key then can be hashed and used as a basis in
+ * a dual encryption scheme, along with AES for faster
+ * two- way encryption.
+ */
+class EcDH implements EcDHInterface
+{
+    /**
+     * Adapter used for math calculations
+     *
+     * @var GmpMathInterface
+     */
+    private $adapter;
+
+    /**
+     * Secret key between the two parties
+     *
+     * @var PointInterface
+     */
+    private $secretKey = null;
+
+    /**
+     *
+     * @var PublicKeyInterface
+     */
+    private $recipientKey;
+
+    /**
+     *
+     * @var PrivateKeyInterface
+     */
+    private $senderKey;
+
+    /**
+     * Initialize a new exchange from a generator point.
+     *
+     * @param GmpMathInterface $adapter A math adapter instance.
+     */
+    public function __construct(GmpMathInterface $adapter)
+    {
+        $this->adapter = $adapter;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\Crypto\EcDH\EcDHInterface::calculateSharedKey()
+     */
+    public function calculateSharedKey()
+    {
+        $this->calculateKey();
+
+        return $this->secretKey->getX();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\Crypto\EcDH\EcDHInterface::createMultiPartyKey()
+     */
+    public function createMultiPartyKey()
+    {
+        $this->calculateKey();
+
+        return new PublicKey($this->adapter, $this->senderKey->getPoint(), $this->secretKey);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\Crypto\EcDH\EcDHInterface::setRecipientKey()
+     */
+    public function setRecipientKey(PublicKeyInterface $key = null)
+    {
+        $this->recipientKey = $key;
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\Crypto\EcDH\EcDHInterface::setSenderKey()
+     */
+    public function setSenderKey(PrivateKeyInterface $key)
+    {
+        $this->senderKey = $key;
+        return $this;
+    }
+
+    /**
+     *
+     */
+    private function calculateKey()
+    {
+        $this->checkExchangeState();
+
+        if ($this->secretKey === null) {
+            $this->secretKey = $this->recipientKey->getPoint()->mul($this->senderKey->getSecret());
+        }
+    }
+
+    /**
+     * Verifies that the shared secret is known, or that the required keys are available
+     * to calculate the shared secret.
+     * @throws \RuntimeException when the exchange has not been made.
+     */
+    private function checkExchangeState()
+    {
+        if ($this->secretKey !== null) {
+            return;
+        }
+
+        if ($this->senderKey === null) {
+            throw new \RuntimeException('Sender key not set.');
+        }
+
+        if ($this->recipientKey === null) {
+            throw new \RuntimeException('Recipient key not set.');
+        }
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Crypto/EcDH/EcDHInterface.php
+++ b/libs/TLS/Mdanter/Ecc/Crypto/EcDH/EcDHInterface.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Mdanter\Ecc\Crypto\EcDH;
+
+/**
+ * *********************************************************************
+ * Copyright (C) 2012 Matyas Danter
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * ***********************************************************************
+ */
+use Mdanter\Ecc\Crypto\Key\PublicKeyInterface;
+use Mdanter\Ecc\Crypto\Key\PrivateKeyInterface;
+
+/**
+ * This is the contract for implementing EcDH (EC Diffie Hellman).
+ */
+interface EcDHInterface
+{
+
+    /**
+     * Calculates and returns the shared key for the exchange.
+     *
+     * @return \GMP
+     */
+    public function calculateSharedKey();
+
+    /**
+     * @return PublicKeyInterface
+     */
+    public function createMultiPartyKey();
+
+    /**
+     * Sets the sender's key.
+     *
+     * @param PrivateKeyInterface $key
+     */
+    public function setSenderKey(PrivateKeyInterface $key);
+
+    /**
+     * Sets the recipient key.
+     *
+     * @param  PublicKeyInterface $key
+     * @return void
+     */
+    public function setRecipientKey(PublicKeyInterface $key);
+}

--- a/libs/TLS/Mdanter/Ecc/Crypto/Key/PrivateKey.php
+++ b/libs/TLS/Mdanter/Ecc/Crypto/Key/PrivateKey.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Mdanter\Ecc\Crypto\Key;
+
+/**
+ * *********************************************************************
+ * Copyright (C) 2012 Matyas Danter
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * ***********************************************************************
+ */
+
+use Mdanter\Ecc\Crypto\EcDH\EcDH;
+use Mdanter\Ecc\Math\GmpMathInterface;
+use Mdanter\Ecc\Primitives\GeneratorPoint;
+
+/**
+ * This class serves as public - private key exchange for signature verification.
+ */
+class PrivateKey implements PrivateKeyInterface
+{
+    /**
+     * @var GeneratorPoint
+     */
+    private $generator;
+
+    /**
+     * @var \GMP
+     */
+    private $secretMultiplier;
+
+    /**
+     * @var GmpMathInterface
+     */
+    private $adapter;
+
+    /**
+     * @param GmpMathInterface $adapter
+     * @param GeneratorPoint $generator
+     * @param \GMP $secretMultiplier
+     */
+    public function __construct(GmpMathInterface $adapter, GeneratorPoint $generator, \GMP $secretMultiplier)
+    {
+        $this->adapter = $adapter;
+        $this->generator = $generator;
+        $this->secretMultiplier = $secretMultiplier;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\Crypto\Key\PrivateKeyInterface::getPublicKey()
+     */
+    public function getPublicKey()
+    {
+        return new PublicKey($this->adapter, $this->generator, $this->generator->mul($this->secretMultiplier));
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\Crypto\Key\PrivateKeyInterface::getPoint()
+     */
+    public function getPoint()
+    {
+        return $this->generator;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\Crypto\Key\PrivateKeyInterface::getCurve()
+     */
+    public function getCurve()
+    {
+        return $this->generator->getCurve();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\Crypto\Key\PrivateKeyInterface::getSecret()
+     */
+    public function getSecret()
+    {
+        return $this->secretMultiplier;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\Crypto\Key\PrivateKeyInterface::createExchange()
+     */
+    public function createExchange(PublicKeyInterface $recipient = null)
+    {
+        $ecdh = new EcDH($this->adapter);
+        $ecdh
+            ->setSenderKey($this)
+            ->setRecipientKey($recipient);
+
+        return $ecdh;
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Crypto/Key/PrivateKeyInterface.php
+++ b/libs/TLS/Mdanter/Ecc/Crypto/Key/PrivateKeyInterface.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Mdanter\Ecc\Crypto\Key;
+
+/**
+ * *********************************************************************
+ * Copyright (C) 2012 Matyas Danter
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * ***********************************************************************
+ */
+
+use Mdanter\Ecc\Crypto\EcDH\EcDHInterface;
+use Mdanter\Ecc\Primitives\GeneratorPoint;
+
+/**
+ * This is a contract for the PrivateKey portion of ECDSA.
+ */
+interface PrivateKeyInterface
+{
+
+    /**
+     * @return PublicKeyInterface
+     */
+    public function getPublicKey();
+
+    /**
+     * @return GeneratorPoint
+     */
+    public function getPoint();
+
+    /**
+     * @return \GMP
+     */
+    public function getSecret();
+
+    /**
+     * @param  PublicKeyInterface $recipient
+     * @return EcDHInterface
+     */
+    public function createExchange(PublicKeyInterface $recipient);
+}

--- a/libs/TLS/Mdanter/Ecc/Crypto/Key/PublicKey.php
+++ b/libs/TLS/Mdanter/Ecc/Crypto/Key/PublicKey.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Mdanter\Ecc\Crypto\Key;
+
+/**
+ * *********************************************************************
+ * Copyright (C) 2012 Matyas Danter
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * ***********************************************************************
+ */
+
+use Mdanter\Ecc\Math\GmpMathInterface;
+use Mdanter\Ecc\Primitives\CurveFpInterface;
+use Mdanter\Ecc\Primitives\GeneratorPoint;
+use Mdanter\Ecc\Primitives\PointInterface;
+
+/**
+ * This class serves as public- private key exchange for signature verification
+ */
+class PublicKey implements PublicKeyInterface
+{
+    /**
+     *
+     * @var CurveFpInterface
+     */
+    protected $curve;
+
+    /**
+     *
+     * @var GeneratorPoint
+     */
+    protected $generator;
+
+    /**
+     *
+     * @var PointInterface
+     */
+    protected $point;
+
+    /**
+     *
+     * @var GmpMathInterface
+     */
+    protected $adapter;
+
+    /**
+     * Initialize a new instance.
+     *
+     * @param  GmpMathInterface $adapter
+     * @param  GeneratorPoint $generator
+     * @param  PointInterface $point
+     * @throws \LogicException
+     * @throws \RuntimeException
+     */
+    public function __construct(GmpMathInterface $adapter, GeneratorPoint $generator, PointInterface $point)
+    {
+        $this->curve = $generator->getCurve();
+        $this->generator = $generator;
+        $this->point = $point;
+        $this->adapter = $adapter;
+
+        $n = $generator->getOrder();
+
+        if ($adapter->cmp($point->getX(), gmp_init(0, 10)) < 0 || $adapter->cmp($n, $point->getX()) <= 0
+            || $adapter->cmp($point->getY(), gmp_init(0, 10)) < 0 || $adapter->cmp($n, $point->getY()) <= 0
+        ) {
+            throw new \RuntimeException("Generator point has x and y out of range.");
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\Crypto\Key\PublicKeyInterface::getCurve()
+     */
+    public function getCurve()
+    {
+        return $this->curve;
+    }
+
+    /**
+     * {$inheritDoc}
+     * @see \Mdanter\Ecc\Crypto\Key\PublicKeyInterface::getGenerator()
+     */
+    public function getGenerator()
+    {
+        return $this->generator;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\Crypto\Key\PublicKeyInterface::getPoint()
+     */
+    public function getPoint()
+    {
+        return $this->point;
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Crypto/Key/PublicKeyInterface.php
+++ b/libs/TLS/Mdanter/Ecc/Crypto/Key/PublicKeyInterface.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Mdanter\Ecc\Crypto\Key;
+
+/**
+ * *********************************************************************
+ * Copyright (C) 2012 Matyas Danter
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * ***********************************************************************
+ */
+use Mdanter\Ecc\Primitives\CurveFpInterface;
+use Mdanter\Ecc\Primitives\PointInterface;
+use Mdanter\Ecc\Primitives\GeneratorPoint;
+
+/**
+ * This is the contract for the PublicKey portion of ECDSA.
+ */
+interface PublicKeyInterface
+{
+
+    /**
+     * @return CurveFpInterface
+     */
+    public function getCurve();
+
+    /**
+     * @return PointInterface
+     */
+    public function getPoint();
+
+    /**
+     * @return GeneratorPoint
+     */
+    public function getGenerator();
+}

--- a/libs/TLS/Mdanter/Ecc/Crypto/Signature/Signature.php
+++ b/libs/TLS/Mdanter/Ecc/Crypto/Signature/Signature.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Mdanter\Ecc\Crypto\Signature;
+
+/**
+ * *********************************************************************
+ * Copyright (C) 2012 Matyas Danter
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * ***********************************************************************
+ */
+
+/**
+ * Plain Old PHP Object that stores the signature r,s for ECDSA
+ */
+class Signature implements SignatureInterface
+{
+    /**
+     * @var \GMP
+     */
+    protected $r;
+
+    /**
+     *
+     * @var \GMP
+     */
+    protected $s;
+
+    /**
+     * Initialize a new instance with values
+     *
+     * @param \GMP $r
+     * @param \GMP $s
+     */
+    public function __construct(\GMP $r, \GMP $s)
+    {
+        $this->r = $r;
+        $this->s = $s;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\Crypto\Signature\SignatureInterface::getR()
+     */
+    public function getR()
+    {
+        return $this->r;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\Crypto\Signature\SignatureInterface::getS()
+     */
+    public function getS()
+    {
+        return $this->s;
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Crypto/Signature/SignatureInterface.php
+++ b/libs/TLS/Mdanter/Ecc/Crypto/Signature/SignatureInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Mdanter\Ecc\Crypto\Signature;
+
+/**
+ * *********************************************************************
+ * Copyright (C) 2012 Matyas Danter
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * ***********************************************************************
+ */
+
+/**
+ * This is the contract for describing a signature used in ECDSA.
+ */
+interface SignatureInterface
+{
+    /**
+     * Returns the r parameter of the signature.
+     *
+     * @return \GMP
+     */
+    public function getR();
+
+    /**
+     * Returns the s parameter of the signature.
+     *
+     * @return \GMP
+     */
+    public function getS();
+}

--- a/libs/TLS/Mdanter/Ecc/Crypto/Signature/Signer.php
+++ b/libs/TLS/Mdanter/Ecc/Crypto/Signature/Signer.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Mdanter\Ecc\Crypto\Signature;
+
+use Mdanter\Ecc\Math\GmpMathInterface;
+use Mdanter\Ecc\Crypto\Key\PrivateKeyInterface;
+use Mdanter\Ecc\Crypto\Key\PublicKeyInterface;
+use Mdanter\Ecc\Primitives\GeneratorPoint;
+use Mdanter\Ecc\Util\NumberSize;
+use Mdanter\Ecc\Util\BinaryString;
+
+class Signer
+{
+
+    /**
+     *
+     * @var GmpMathInterface
+     */
+    private $adapter;
+
+    /**
+     *
+     * @param GmpMathInterface $adapter
+     */
+    public function __construct(GmpMathInterface $adapter)
+    {
+        $this->adapter = $adapter;
+    }
+
+    /**
+     * @param GeneratorPoint $G
+     * @param \GMP $hash
+     * @return \GMP
+     */
+    public function truncateHash(GeneratorPoint $G, \GMP $hash)
+    {
+        $dec = $this->adapter->toString($hash);
+        $hexSize = BinaryString::length($this->adapter->decHex($dec));
+        $hashBits = $this->adapter->baseConvert($dec, 10, 2);
+        if (BinaryString::length($hashBits) < $hexSize * 4) {
+            $hashBits = str_pad($hashBits, $hexSize * 4, '0', STR_PAD_LEFT);
+        }
+
+        $messageHash = gmp_init(BinaryString::substring($hashBits, 0, NumberSize::bnNumBits($this->adapter, $G->getOrder())), 2);
+        return $messageHash;
+    }
+
+    /**
+     * @param GeneratorPoint $G
+     * @param string $algorithm
+     * @param string $data
+     * @return \GMP
+     */
+    public function hashData(GeneratorPoint $G, $algorithm, $data)
+    {
+        if (!in_array($algorithm, hash_algos())) {
+            throw new \InvalidArgumentException('Unsupported hashing algorithm');
+        }
+
+        $hash = gmp_init(hash($algorithm, $data, false), 16);
+        return $this->truncateHash($G, $hash);
+    }
+
+    /**
+     * @param PrivateKeyInterface $key
+     * @param \GMP $hash
+     * @param \GMP $randomK
+     * @return Signature
+     */
+    public function sign(PrivateKeyInterface $key, \GMP $hash, \GMP $randomK)
+    {
+        $math = $this->adapter;
+        $generator = $key->getPoint();
+        $modMath = $math->getModularArithmetic($generator->getOrder());
+
+        $hash = $this->truncateHash($generator, $hash);
+        $k = $math->mod($randomK, $generator->getOrder());
+        $p1 = $generator->mul($k);
+        $r = $p1->getX();
+        $zero = gmp_init(0, 10);
+        if ($math->equals($r, $zero)) {
+            throw new \RuntimeException("Error: random number R = 0");
+        }
+
+        $hash = $this->truncateHash($generator, $hash);
+        $s = $modMath->div($modMath->add($hash, $math->mul($key->getSecret(), $r)), $k);
+        if ($math->equals($s, $zero)) {
+            throw new \RuntimeException("Error: random number S = 0");
+        }
+
+        return new Signature($r, $s);
+    }
+
+    /**
+     * @param PublicKeyInterface $key
+     * @param SignatureInterface $signature
+     * @param \GMP $hash
+     * @return bool
+     */
+    public function verify(PublicKeyInterface $key, SignatureInterface $signature, \GMP $hash)
+    {
+        $generator = $key->getGenerator();
+        $n = $generator->getOrder();
+        $r = $signature->getR();
+        $s = $signature->getS();
+
+        $math = $this->adapter;
+        $one = gmp_init(1, 10);
+        if ($math->cmp($r, $one) < 1 || $math->cmp($r, $math->sub($n, $one)) > 0) {
+            return false;
+        }
+
+        if ($math->cmp($s, $one) < 1 || $math->cmp($s, $math->sub($n, $one)) > 0) {
+            return false;
+        }
+
+        $modMath = $math->getModularArithmetic($n);
+        $c = $math->inverseMod($s, $n);
+        $u1 = $modMath->mul($hash, $c);
+        $u2 = $modMath->mul($r, $c);
+        $xy = $generator->mul($u1)->add($key->getPoint()->mul($u2));
+        $v = $math->mod($xy->getX(), $n);
+
+        return BinaryString::constantTimeCompare($math->toString($v), $math->toString($r));
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Curves/CurveFactory.php
+++ b/libs/TLS/Mdanter/Ecc/Curves/CurveFactory.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Mdanter\Ecc\Curves;
+
+use Mdanter\Ecc\Math\GmpMathInterface;
+use Mdanter\Ecc\Math\MathAdapterFactory;
+
+class CurveFactory
+{
+    /**
+     * @param $name
+     * @return NamedCurveFp|\Mdanter\Ecc\Primitives\CurveFp|\Mdanter\Ecc\Primitives\CurveFpInterface
+     */
+    public static function getCurveByName($name)
+    {
+        $adapter = MathAdapterFactory::getAdapter();
+        $nistFactory = self::getNistFactory($adapter);
+        $secpFactory = self::getSecpFactory($adapter);
+
+        switch ($name) {
+            case NistCurve::NAME_P192:
+                return $nistFactory->curve192();
+            case NistCurve::NAME_P224:
+                return $nistFactory->curve224();
+            case NistCurve::NAME_P256:
+                return $nistFactory->curve256();
+            case NistCurve::NAME_P384:
+                return $nistFactory->curve384();
+            case NistCurve::NAME_P521:
+                return $nistFactory->curve521();
+            case SecgCurve::NAME_SECP_112R1:
+                return $secpFactory->curve112r1();
+            case SecgCurve::NAME_SECP_256K1:
+                return $secpFactory->curve256k1();
+            case SecgCurve::NAME_SECP_256R1:
+                return $secpFactory->curve256r1();
+            case SecgCurve::NAME_SECP_384R1:
+                return $secpFactory->curve384r1();
+            default:
+                throw new \RuntimeException('Unknown curve.');
+        }
+    }
+
+    /**
+     * @param $name
+     * @return \Mdanter\Ecc\Primitives\GeneratorPoint
+     */
+    public static function getGeneratorByName($name)
+    {
+        $adapter = MathAdapterFactory::getAdapter();
+        $nistFactory = self::getNistFactory($adapter);
+        $secpFactory = self::getSecpFactory($adapter);
+
+        switch ($name) {
+            case NistCurve::NAME_P192:
+                return $nistFactory->generator192();
+            case NistCurve::NAME_P224:
+                return $nistFactory->generator224();
+            case NistCurve::NAME_P256:
+                return $nistFactory->generator256();
+            case NistCurve::NAME_P384:
+                return $nistFactory->generator384();
+            case NistCurve::NAME_P521:
+                return $nistFactory->generator521();
+            case SecgCurve::NAME_SECP_112R1:
+                return $secpFactory->generator112r1();
+            case SecgCurve::NAME_SECP_256K1:
+                return $secpFactory->generator256k1();
+            case SecgCurve::NAME_SECP_256R1:
+                return $secpFactory->generator256r1();
+            case SecgCurve::NAME_SECP_384R1:
+                return $secpFactory->generator384r1();
+            default:
+                throw new \RuntimeException('Unknown generator.');
+        }
+    }
+
+    /**
+     * @return NistCurve
+     */
+    private static function getNistFactory(GmpMathInterface $math)
+    {
+        return new NistCurve($math);
+    }
+
+    /**
+     * @return SecgCurve
+     */
+    private static function getSecpFactory(GmpMathInterface $math)
+    {
+        return new SecgCurve($math);
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Curves/NamedCurveFp.php
+++ b/libs/TLS/Mdanter/Ecc/Curves/NamedCurveFp.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Mdanter\Ecc\Curves;
+
+use Mdanter\Ecc\Math\GmpMathInterface;
+use Mdanter\Ecc\Primitives\CurveFp;
+use Mdanter\Ecc\Primitives\CurveParameters;
+
+class NamedCurveFp extends CurveFp
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @param string $name
+     * @param CurveParameters $parameters
+     * @param GmpMathInterface $adapter
+     */
+    public function __construct($name, CurveParameters $parameters, GmpMathInterface $adapter)
+    {
+        $this->name = $name;
+
+        parent::__construct($parameters, $adapter);
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Curves/NistCurve.php
+++ b/libs/TLS/Mdanter/Ecc/Curves/NistCurve.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace Mdanter\Ecc\Curves;
+
+use Mdanter\Ecc\Math\GmpMathInterface;
+use Mdanter\Ecc\Primitives\CurveFp;
+use Mdanter\Ecc\Primitives\CurveFpInterface;
+use Mdanter\Ecc\Primitives\CurveParameters;
+use Mdanter\Ecc\Primitives\GeneratorPoint;
+use Mdanter\Ecc\Random\RandomNumberGeneratorInterface;
+
+/**
+ * *********************************************************************
+ * Copyright (C) 2012 Matyas Danter
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * ***********************************************************************
+ */
+
+/**
+ * This class encapsulates the NIST recommended curves
+ * - fields are Mersenne primes, i.e.
+ * for some p, Mersenne_prine = 2^p - 1
+ */
+class NistCurve
+{
+    const NAME_P192 = 'nistp192';
+    const NAME_P224 = 'nistp224';
+    const NAME_P256 = 'nistp256';
+    const NAME_P384 = 'nistp384';
+    const NAME_P521 = 'nistp521';
+
+    /**
+     * @var GmpMathInterface
+     */
+    private $adapter;
+
+    /**
+     * @param GmpMathInterface $adapter
+     */
+    public function __construct(GmpMathInterface $adapter)
+    {
+        $this->adapter = $adapter;
+    }
+
+    /**
+     * Returns an NIST P-192 curve.
+     *
+     * @return CurveFpInterface
+     */
+    public function curve192()
+    {
+        $p = gmp_init('6277101735386680763835789423207666416083908700390324961279', 10);
+        $b = gmp_init('64210519e59c80e70fa7e9ab72243049feb8deecc146b9b1', 16);
+
+        $parameters = new CurveParameters(192, $p, gmp_init('-3', 10), $b);
+
+        return new NamedCurveFp(self::NAME_P192, $parameters, $this->adapter);
+    }
+
+    /**
+     * Returns an NIST P-192 generator.
+     *
+     * @param  RandomNumberGeneratorInterface $randomGenerator
+     * @return GeneratorPoint
+     */
+    public function generator192(RandomNumberGeneratorInterface $randomGenerator = null)
+    {
+        $curve = $this->curve192();
+        $order = gmp_init('6277101735386680763835789423176059013767194773182842284081', 10);
+
+        $x = gmp_init('188da80eb03090f67cbf20eb43a18800f4ff0afd82ff1012', 16);
+        $y = gmp_init('07192b95ffc8da78631011ed6b24cdd573f977a11e794811', 16);
+
+        return $curve->getGenerator($x, $y, $order, $randomGenerator);
+    }
+
+    /**
+     * Returns an NIST P-224 curve
+     *
+     * @return CurveFpInterface
+     */
+    public function curve224()
+    {
+        $p = gmp_init('26959946667150639794667015087019630673557916260026308143510066298881', 10);
+        $b = gmp_init('b4050a850c04b3abf54132565044b0b7d7bfd8ba270b39432355ffb4', 16);
+
+        $parameters = new CurveParameters(224, $p, gmp_init(-3, 10), $b);
+
+        return new NamedCurveFp(self::NAME_P224, $parameters, $this->adapter);
+    }
+
+    /**
+     * Returns an NIST P-224 generator.
+     *
+     * @param  RandomNumberGeneratorInterface $randomGenerator
+     * @return GeneratorPoint
+     */
+    public function generator224(RandomNumberGeneratorInterface $randomGenerator = null)
+    {
+        $curve = $this->curve224();
+        $order = gmp_init('26959946667150639794667015087019625940457807714424391721682722368061', 10);
+
+        $x = gmp_init('b70e0cbd6bb4bf7f321390b94a03c1d356c21122343280d6115c1d21', 16);
+        $y = gmp_init('bd376388b5f723fb4c22dfe6cd4375a05a07476444d5819985007e34', 16);
+
+        return $curve->getGenerator($x, $y, $order, $randomGenerator);
+    }
+
+    /**
+     * Returns an NIST P-256 curve.
+     *
+     * @return CurveFp
+     */
+    public function curve256()
+    {
+        $p = gmp_init('115792089210356248762697446949407573530086143415290314195533631308867097853951', 10);
+        $b = gmp_init('0x5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b', 16);
+
+        $parameters = new CurveParameters(256, $p, gmp_init(-3, 10), $b);
+
+        return new NamedCurveFp(self::NAME_P256, $parameters, $this->adapter);
+    }
+
+    /**
+     * Returns an NIST P-256 generator.
+     *
+     * @param  RandomNumberGeneratorInterface $randomGenerator
+     * @return GeneratorPoint
+     */
+    public function generator256(RandomNumberGeneratorInterface $randomGenerator = null)
+    {
+        $curve = $this->curve256();
+        $order = gmp_init('115792089210356248762697446949407573529996955224135760342422259061068512044369', 10);
+
+        $x = gmp_init('0x6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296', 16);
+        $y = gmp_init('0x4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5', 16);
+
+        return $curve->getGenerator($x, $y, $order, $randomGenerator);
+    }
+
+    /**
+     * Returns an NIST P-384 curve.
+     *
+     * @return CurveFp
+     */
+    public function curve384()
+    {
+        $p = gmp_init('39402006196394479212279040100143613805079739270465446667948293404245721771496870329047266088258938001861606973112319', 10);
+        $b = gmp_init('0xb3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8a2ed19d2a85c8edd3ec2aef', 16);
+
+        $parameters = new CurveParameters(384, $p, gmp_init(-3, 10), $b);
+
+        return new NamedCurveFp(self::NAME_P384, $parameters, $this->adapter);
+    }
+
+    /**
+     * Returns an NIST P-384 generator.
+     *
+     * @param  RandomNumberGeneratorInterface $randomGenerator
+     * @return GeneratorPoint
+     */
+    public function generator384(RandomNumberGeneratorInterface $randomGenerator = null)
+    {
+        $curve = $this->curve384();
+        $order = gmp_init('39402006196394479212279040100143613805079739270465446667946905279627659399113263569398956308152294913554433653942643', 10);
+
+        $x = gmp_init('0xaa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7', 16);
+        $y = gmp_init('0x3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f', 16);
+
+        return $curve->getGenerator($x, $y, $order, $randomGenerator);
+    }
+
+    /**
+     * Returns an NIST P-521 curve.
+     *
+     * @return CurveFp
+     */
+    public function curve521()
+    {
+        $p = gmp_init('6864797660130609714981900799081393217269435300143305409394463459185543183397656052122559640661454554977296311391480858037121987999716643812574028291115057151', 10);
+        $b = gmp_init('0x051953eb9618e1c9a1f929a21a0b68540eea2da725b99b315f3b8b489918ef109e156193951ec7e937b1652c0bd3bb1bf073573df883d2c34f1ef451fd46b503f00', 16);
+
+        $parameters = new CurveParameters(521, $p, gmp_init(-3, 10), $b);
+
+        return new NamedCurveFp(self::NAME_P521, $parameters, $this->adapter);
+    }
+
+    /**
+     * Returns an NIST P-521 generator.
+     *
+     * @param  RandomNumberGeneratorInterface $randomGenerator
+     * @return GeneratorPoint
+     */
+    public function generator521(RandomNumberGeneratorInterface $randomGenerator = null)
+    {
+        $curve = $this->curve521();
+        $order = gmp_init('6864797660130609714981900799081393217269435300143305409394463459185543183397655394245057746333217197532963996371363321113864768612440380340372808892707005449', 10);
+
+        $x = gmp_init('0xc6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd66', 16);
+        $y = gmp_init('0x11839296a789a3bc0045c8a5fb42c7d1bd998f54449579b446817afbd17273e662c97ee72995ef42640c550b9013fad0761353c7086a272c24088be94769fd16650', 16);
+
+        return $curve->getGenerator($x, $y, $order, $randomGenerator);
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Curves/SecgCurve.php
+++ b/libs/TLS/Mdanter/Ecc/Curves/SecgCurve.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Mdanter\Ecc\Curves;
+
+use Mdanter\Ecc\Math\GmpMathInterface;
+use Mdanter\Ecc\Primitives\CurveParameters;
+use Mdanter\Ecc\Random\RandomNumberGeneratorInterface;
+
+/**
+ * *********************************************************************
+ * Copyright (C) 2012 Matyas Danter
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * ***********************************************************************
+ */
+
+/**
+ *
+ */
+class SecgCurve
+{
+    /**
+     * @var GmpMathInterface
+     */
+    private $adapter;
+
+    const NAME_SECP_112R1 = 'secp112r1';
+    const NAME_SECP_256K1 = 'secp256k1';
+    const NAME_SECP_256R1 = 'secp256r1';
+    const NAME_SECP_384R1 = 'secp384r1';
+
+    /**
+     * @param GmpMathInterface $adapter
+     */
+    public function __construct(GmpMathInterface $adapter)
+    {
+        $this->adapter = $adapter;
+    }
+
+    /**
+     * @return NamedCurveFp
+     */
+    public function curve112r1()
+    {
+        $p = gmp_init('0xDB7C2ABF62E35E668076BEAD208B', 16);
+        $a = gmp_init('0xDB7C2ABF62E35E668076BEAD2088', 16);
+        $b = gmp_init('0x659EF8BA043916EEDE8911702B22', 16);
+
+        $parameters = new CurveParameters(112, $p, $a, $b);
+
+        return new NamedCurveFp(self::NAME_SECP_112R1, $parameters, $this->adapter);
+    }
+
+    /**
+     * @param RandomNumberGeneratorInterface $randomGenerator
+     * @return \Mdanter\Ecc\Primitives\GeneratorPoint
+     */
+    public function generator112r1(RandomNumberGeneratorInterface $randomGenerator = null)
+    {
+        $curve = $this->curve112r1();
+
+        $order = gmp_init('0xDB7C2ABF62E35E7628DFAC6561C5', 16);
+        $x = gmp_init('0x09487239995A5EE76B55F9C2F098', 16);
+        $y = gmp_init('0xA89CE5AF8724C0A23E0E0FF77500', 16);
+
+        return $curve->getGenerator($x, $y, $order, $randomGenerator);
+    }
+
+    /**
+     * @return NamedCurveFp
+     */
+    public function curve256k1()
+    {
+        $p = gmp_init('FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F', 16);
+        $a = gmp_init(0, 10);
+        $b = gmp_init(7, 10);
+
+        $parameters = new CurveParameters(256, $p, $a, $b);
+
+        return new NamedCurveFp(self::NAME_SECP_256K1, $parameters, $this->adapter);
+    }
+
+    /**
+     * @param RandomNumberGeneratorInterface $randomGenerator
+     * @return \Mdanter\Ecc\Primitives\GeneratorPoint
+     */
+    public function generator256k1(RandomNumberGeneratorInterface $randomGenerator = null)
+    {
+        $curve = $this->curve256k1();
+
+        $order = gmp_init('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141', 16);
+        $x = gmp_init('0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798', 16);
+        $y = gmp_init('0x483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8', 16);
+
+        return $curve->getGenerator($x, $y, $order, $randomGenerator);
+    }
+
+    /**
+     * @return NamedCurveFp
+     */
+    public function curve256r1()
+    {
+        $p = gmp_init('0xFFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF', 16);
+        $a = gmp_init('0xFFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFC', 16);
+        $b = gmp_init('0x5AC635D8AA3A93E7B3EBBD55769886BC651D06B0CC53B0F63BCE3C3E27D2604B', 16);
+
+        $parameters = new CurveParameters(256, $p, $a, $b);
+
+        return new NamedCurveFp(self::NAME_SECP_256R1, $parameters, $this->adapter);
+    }
+
+    /**
+     * @param RandomNumberGeneratorInterface $randomGenerator
+     * @return \Mdanter\Ecc\Primitives\GeneratorPoint
+     */
+    public function generator256r1(RandomNumberGeneratorInterface $randomGenerator = null)
+    {
+        $curve = $this->curve256r1();
+
+        $order = gmp_init('0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551', 16);
+        $x = gmp_init('0x6B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C296', 16);
+        $y = gmp_init('0x4FE342E2FE1A7F9B8EE7EB4A7C0F9E162BCE33576B315ECECBB6406837BF51F5', 16);
+
+        return $curve->getGenerator($x, $y, $order, $randomGenerator);
+    }
+
+    /**
+     * @return NamedCurveFp
+     */
+    public function curve384r1()
+    {
+        $p = gmp_init('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFFFF0000000000000000FFFFFFFF', 16);
+        $a = gmp_init('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFFFF0000000000000000FFFFFFFC', 16);
+        $b = gmp_init('0xB3312FA7E23EE7E4988E056BE3F82D19181D9C6EFE8141120314088F5013875AC656398D8A2ED19D2A85C8EDD3EC2AEF', 16);
+
+        $parameters = new CurveParameters(384, $p, $a, $b);
+
+        return new NamedCurveFp(self::NAME_SECP_384R1, $parameters, $this->adapter);
+    }
+
+    /**
+     * @param RandomNumberGeneratorInterface $randomGenerator
+     * @return \Mdanter\Ecc\Primitives\GeneratorPoint
+     */
+    public function generator384r1(RandomNumberGeneratorInterface $randomGenerator = null)
+    {
+        $curve = $this->curve384r1();
+
+        $order = gmp_init('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC7634D81F4372DDF581A0DB248B0A77AECEC196ACCC52973', 16);
+        $x = gmp_init('0xAA87CA22BE8B05378EB1C71EF320AD746E1D3B628BA79B9859F741E082542A385502F25DBF55296C3A545E3872760AB7', 16);
+        $y = gmp_init('0x3617DE4A96262C6F5D9E98BF9292DC29F8F41DBD289A147CE9DA3113B5F0B8C00A60B1CE1D7E819D7A431D7C90EA0E5F', 16);
+
+        return $curve->getGenerator($x, $y, $order, $randomGenerator);
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/EccFactory.php
+++ b/libs/TLS/Mdanter/Ecc/EccFactory.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Mdanter\Ecc;
+
+use Mdanter\Ecc\Crypto\Signature\Signer;
+use Mdanter\Ecc\Curves\NistCurve;
+use Mdanter\Ecc\Curves\SecgCurve;
+use Mdanter\Ecc\Math\GmpMathInterface;
+use Mdanter\Ecc\Math\MathAdapterFactory;
+use Mdanter\Ecc\Primitives\CurveFp;
+use Mdanter\Ecc\Primitives\CurveParameters;
+
+/**
+ * Static factory class providing factory methods to work with NIST and SECG recommended curves.
+ */
+class EccFactory
+{
+    /**
+     * Selects and creates the most appropriate adapter for the running environment.
+     *
+     * @param $debug [optional] Set to true to get a trace of all mathematical operations
+     *
+     * @throws \RuntimeException
+     * @return GmpMathInterface
+     */
+    public static function getAdapter($debug = false)
+    {
+        return MathAdapterFactory::getAdapter($debug);
+    }
+
+    /**
+     * Returns a factory to create NIST Recommended curves and generators.
+     *
+     * @param  GmpMathInterface $adapter [optional] Defaults to the return value of EccFactory::getAdapter().
+     * @return NistCurve
+     */
+    public static function getNistCurves(GmpMathInterface $adapter = null)
+    {
+        return new NistCurve($adapter ?: self::getAdapter());
+    }
+
+    /**
+     * Returns a factory to return SECG Recommended curves and generators.
+     *
+     * @param  GmpMathInterface $adapter [optional] Defaults to the return value of EccFactory::getAdapter().
+     * @return SecgCurve
+     */
+    public static function getSecgCurves(GmpMathInterface $adapter = null)
+    {
+        return new SecgCurve($adapter ?: self::getAdapter());
+    }
+
+    /**
+     * Creates a new curve from arbitrary parameters.
+     *
+     * @param  \GMP $prime
+     * @param  \GMP $a
+     * @param  \GMP $b
+     * @param  GmpMathInterface $adapter [optional] Defaults to the return value of EccFactory::getAdapter().
+     * @return \Mdanter\Ecc\Primitives\CurveFpInterface
+     */
+    public static function createCurve($bitSize, \GMP $prime, \GMP $a, \GMP $b, GmpMathInterface $adapter = null)
+    {
+        return new CurveFp(new CurveParameters($bitSize, $prime, $a, $b), $adapter ?: self::getAdapter());
+    }
+
+    /**
+     *
+     * @param  GmpMathInterface $adapter [optional] Defaults to the return value of EccFactory::getAdapteR()
+     * @return \Mdanter\Ecc\Crypto\Signature\Signer
+     */
+    public static function getSigner(GmpMathInterface $adapter = null)
+    {
+        return new Signer($adapter ?: self::getAdapter());
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Math/DebugDecorator.php
+++ b/libs/TLS/Mdanter/Ecc/Math/DebugDecorator.php
@@ -1,0 +1,621 @@
+<?php
+
+namespace Mdanter\Ecc\Math;
+
+use Mdanter\Ecc\Primitives\CurveFpInterface;
+use Mdanter\Ecc\Primitives\GeneratorPoint;
+
+/**
+ * Debug helper class to trace all calls to math functions along with the provided params and result.
+ */
+class DebugDecorator implements GmpMathInterface
+{
+    /**
+     * @var GmpMathInterface
+     */
+    private $adapter;
+
+    /**
+     * @var callable
+     */
+    private $writer;
+
+    /**
+     * @param GmpMathInterface $adapter
+     * @param callable|null $callback
+     */
+    public function __construct(GmpMathInterface $adapter, callable $callback = null)
+    {
+        $this->adapter = $adapter;
+        $this->writer = $callback ?: function ($message) {
+            echo $message;
+        };
+    }
+
+    /**
+     *
+     * @param string $message
+     */
+    private function write($message)
+    {
+        call_user_func($this->writer, $message);
+    }
+
+    /**
+     *
+     * @param  string $func
+     * @param  array $args
+     * @return mixed
+     */
+    private function call($func, $args)
+    {
+        $strArgs = array_map(
+            function ($arg) {
+                if ($arg instanceof \GMP) {
+                    return var_export($this->adapter->toString($arg), true);
+                } else {
+                    return var_export($arg, true);
+                }
+            },
+            $args
+        );
+
+        if (strpos($func, '::')) {
+            list(, $func) = explode('::', $func);
+        }
+
+        $this->write($func . '(' . implode(', ', $strArgs) . ')');
+
+        $res = call_user_func_array([$this->adapter, $func], $args);
+
+        if ($res instanceof \GMP) {
+            $this->write(' => ' . var_export($this->adapter->toString($res), true) . PHP_EOL);
+        } else {
+            $this->write(' => ' . var_export($res, true) . PHP_EOL);
+        }
+
+        return $res;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::cmp()
+     */
+    public function cmp(\GMP $first, \GMP $other)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call',
+            ],
+            $func,
+            $args
+        );
+    }
+
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::cmp()
+     */
+    public function equals(\GMP $first, \GMP $other)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call',
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::mod()
+     */
+    public function mod(\GMP $number, \GMP $modulus)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call',
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::add()
+     */
+    public function add(\GMP $augend, \GMP $addend)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call',
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::sub()
+     */
+    public function sub(\GMP $minuend, \GMP $subtrahend)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call',
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::mul()
+     */
+    public function mul(\GMP $multiplier, \GMP $multiplicand)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call',
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::div()
+     */
+    public function div(\GMP $dividend, \GMP $divisor)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call',
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::pow()
+     */
+    public function pow(\GMP $base, $exponent)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call',
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::bitwiseAnd()
+     */
+    public function bitwiseAnd(\GMP $first, \GMP $other)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call',
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\MathAdapter::toString()
+     */
+    public function toString(\GMP $value)
+    {
+        return $this->adapter->toString($value);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::hexDec()
+     */
+    public function hexDec($hexString)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call',
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::decHex()
+     */
+    public function decHex($decString)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call',
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::powmod()
+     */
+    public function powmod(\GMP $base, \GMP $exponent, \GMP $modulus)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call',
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::isPrime()
+     */
+    public function isPrime(\GMP $n)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call',
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::nextPrime()
+     */
+    public function nextPrime(\GMP $currentPrime)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call',
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::inverseMod()
+     */
+    public function inverseMod(\GMP $a, \GMP $m)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call',
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::jacobi()
+     */
+    public function jacobi(\GMP $a, \GMP $p)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call',
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::intToString()
+     */
+    public function intToString(\GMP $x)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call',
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::stringToInt()
+     */
+    public function stringToInt($s)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call',
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::digestInteger()
+     */
+    public function digestInteger(\GMP $m)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call',
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::gcd2()
+     */
+    public function gcd2(\GMP $a, \GMP $m)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call',
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::rightShift()
+     */
+    public function rightShift(\GMP $number, $positions)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call',
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::leftShift()
+     */
+    public function leftShift(\GMP $number, $positions)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call',
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::bitwiseXor()
+     */
+    public function bitwiseXor(\GMP $first, \GMP $other)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call'
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::baseConvert()
+     */
+    public function baseConvert($value, $fromBase, $toBase)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call'
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::getEcMath()
+     */
+    public function getEcMath(GeneratorPoint $generatorPoint, $input)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call'
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::getPrimeFieldArithmetic()
+     */
+    public function getPrimeFieldArithmetic(CurveFpInterface $curve)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call'
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::getModularArithmetic()
+     */
+    public function getModularArithmetic(\GMP $modulus)
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call'
+            ],
+            $func,
+            $args
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\GmpMathInterface::getNumberTheory()
+     */
+    public function getNumberTheory()
+    {
+        $func = __METHOD__;
+        $args = func_get_args();
+
+        return call_user_func(
+            [
+                $this,
+                'call'
+            ],
+            $func,
+            $args
+        );
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Math/GmpMath.php
+++ b/libs/TLS/Mdanter/Ecc/Math/GmpMath.php
@@ -1,0 +1,303 @@
+<?php
+
+namespace Mdanter\Ecc\Math;
+
+use Mdanter\Ecc\Util\BinaryString;
+
+class GmpMath implements GmpMathInterface
+{
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::cmp()
+     */
+    public function cmp(\GMP $first, \GMP $other)
+    {
+        return gmp_cmp($first, $other);
+    }
+
+    /**
+     * @param \GMP $first
+     * @param \GMP $other
+     * @return bool
+     */
+    public function equals(\GMP $first, \GMP $other)
+    {
+        return gmp_cmp($first, $other) === 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::mod()
+     */
+    public function mod(\GMP $number, \GMP $modulus)
+    {
+        return gmp_mod($number, $modulus);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::add()
+     */
+    public function add(\GMP $augend, \GMP $addend)
+    {
+        return gmp_add($augend, $addend);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::sub()
+     */
+    public function sub(\GMP $minuend, \GMP $subtrahend)
+    {
+        return gmp_sub($minuend, $subtrahend);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::mul()
+     */
+    public function mul(\GMP $multiplier, \GMP $multiplicand)
+    {
+        return gmp_mul($multiplier, $multiplicand);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::div()
+     */
+    public function div(\GMP $dividend, \GMP $divisor)
+    {
+        return gmp_div($dividend, $divisor);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::pow()
+     */
+    public function pow(\GMP $base, $exponent)
+    {
+        return gmp_pow($base, $exponent);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::bitwiseAnd()
+     */
+    public function bitwiseAnd(\GMP $first, \GMP $other)
+    {
+        return gmp_and($first, $other);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::rightShift()
+     */
+    public function rightShift(\GMP $number, $positions)
+    {
+        // Shift 1 right = div / 2
+        return gmp_div($number, gmp_pow(gmp_init(2, 10), $positions));
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::bitwiseXor()
+     */
+    public function bitwiseXor(\GMP $first, \GMP $other)
+    {
+        return gmp_xor($first, $other);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::leftShift()
+     */
+    public function leftShift(\GMP $number, $positions)
+    {
+        // Shift 1 left = mul by 2
+        return gmp_mul($number, gmp_pow(2, $positions));
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::toString()
+     */
+    public function toString(\GMP $value)
+    {
+        return gmp_strval($value);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::hexDec()
+     */
+    public function hexDec($hex)
+    {
+        return gmp_strval(gmp_init($hex, 16), 10);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::decHex()
+     */
+    public function decHex($dec)
+    {
+        $hex = gmp_strval(gmp_init($dec, 10), 16);
+
+        if (BinaryString::length($hex) % 2 != 0) {
+            $hex = '0' . $hex;
+        }
+
+        return $hex;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::powmod()
+     */
+    public function powmod(\GMP $base, \GMP $exponent, \GMP $modulus)
+    {
+        if ($this->cmp($exponent, gmp_init(0, 10)) < 0) {
+            throw new \InvalidArgumentException("Negative exponents (" . $this->toString($exponent) . ") not allowed.");
+        }
+
+        return gmp_powm($base, $exponent, $modulus);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::isPrime()
+     */
+    public function isPrime(\GMP $n)
+    {
+        $prob = gmp_prob_prime($n);
+
+        if ($prob > 0) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::nextPrime()
+     */
+    public function nextPrime(\GMP $starting_value)
+    {
+        return gmp_nextprime($starting_value);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::inverseMod()
+     */
+    public function inverseMod(\GMP $a, \GMP $m)
+    {
+        return gmp_invert($a, $m);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::jacobi()
+     */
+    public function jacobi(\GMP $a, \GMP $n)
+    {
+        return gmp_jacobi($a, $n);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::intToString()
+     */
+    public function intToString(\GMP $x)
+    {
+        if (gmp_cmp($x, 0) == 0) {
+            return chr(0);
+        }
+
+        if (gmp_cmp($x, 0) > 0) {
+            $result = "";
+
+            while (gmp_cmp($x, 0) > 0) {
+                $q = gmp_div($x, 256, 0);
+                $r = gmp_mod($x, 256);
+
+                $ascii = chr(gmp_strval($r));
+
+                $result = $ascii . $result;
+                $x = $q;
+            }
+
+            return $result;
+        }
+
+        throw new \RuntimeException('Unable to convert int to string');
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::stringToInt()
+     */
+    public function stringToInt($s)
+    {
+        $result = gmp_init(0, 10);
+        $sLen = BinaryString::length($s);
+
+        for ($c = 0; $c < $sLen; $c++) {
+            $result = gmp_add(gmp_mul(256, $result), gmp_init(ord($s[$c]), 10));
+        }
+
+        return $result;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::digestInteger()
+     */
+    public function digestInteger(\GMP $m)
+    {
+        return $this->stringToInt(hash('sha1', $this->intToString($m), true));
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::gcd2()
+     */
+    public function gcd2(\GMP $a, \GMP $b)
+    {
+        while ($this->cmp($a, gmp_init(0)) > 0) {
+            $temp = $a;
+            $a = $this->mod($b, $a);
+            $b = $temp;
+        }
+
+        return $b;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::baseConvert()
+     */
+    public function baseConvert($number, $from, $to)
+    {
+        return gmp_strval(gmp_init($number, $from), $to);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see GmpMathInterface::getNumberTheory()
+     */
+    public function getNumberTheory()
+    {
+        return new NumberTheory($this);
+    }
+
+    /**
+     * @param \GMP $modulus
+     * @return ModularArithmetic
+     */
+    public function getModularArithmetic(\GMP $modulus)
+    {
+        return new ModularArithmetic($this, $modulus);
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Math/GmpMathInterface.php
+++ b/libs/TLS/Mdanter/Ecc/Math/GmpMathInterface.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace Mdanter\Ecc\Math;
+
+interface GmpMathInterface
+{
+    /**
+     * Compares two numbers
+     *
+     * @param  \GMP $first
+     * @param  \GMP $other
+     * @return int        less than 0 if first is less than second, 0 if equal, greater than 0 if greater than.
+     */
+    public function cmp(\GMP $first, \GMP $other);
+
+    /**
+     * @param \GMP $first
+     * @param \GMP $other
+     * @return bool
+     */
+    public function equals(\GMP $first, \GMP $other);
+
+    /**
+     * Returns the remainder of a division
+     *
+     * @param  \GMP $number
+     * @param  \GMP $modulus
+     * @return \GMP
+     */
+    public function mod(\GMP $number, \GMP $modulus);
+
+    /**
+     * Adds two numbers
+     *
+     * @param  \GMP $augend
+     * @param  \GMP $addend
+     * @return \GMP
+     */
+    public function add(\GMP $augend, \GMP $addend);
+
+    /**
+     * Substract one number from another
+     *
+     * @param  \GMP $minuend
+     * @param  \GMP $subtrahend
+     * @return \GMP
+     */
+    public function sub(\GMP $minuend, \GMP $subtrahend);
+
+    /**
+     * Multiplies a number by another.
+     *
+     * @param  \GMP $multiplier
+     * @param  \GMP $multiplicand
+     * @return \GMP
+     */
+    public function mul(\GMP $multiplier, \GMP $multiplicand);
+
+    /**
+     * Divides a number by another.
+     *
+     * @param  \GMP $dividend
+     * @param  \GMP $divisor
+     * @return \GMP
+     */
+    public function div(\GMP $dividend, \GMP $divisor);
+
+    /**
+     * Raises a number to a power.
+     *
+     * @param  \GMP $base The number to raise.
+     * @param  int $exponent The power to raise the number to.
+     * @return \GMP
+     */
+    public function pow(\GMP $base, $exponent);
+
+    /**
+     * Performs a logical AND between two values.
+     *
+     * @param  \GMP $first
+     * @param  \GMP $other
+     * @return \GMP
+     */
+    public function bitwiseAnd(\GMP $first, \GMP $other);
+
+    /**
+     * Performs a logical XOR between two values.
+     *
+     * @param  \GMP $first
+     * @param  \GMP $other
+     * @return \GMP
+     */
+    public function bitwiseXor(\GMP $first, \GMP $other);
+
+    /**
+     * Shifts bits to the right
+     * @param \GMP $number Number to shift
+     * @param int $positions Number of positions to shift
+     * @return \GMP
+     */
+    public function rightShift(\GMP $number, $positions);
+
+    /**
+     * Shifts bits to the left
+     * @param \GMP $number Number to shift
+     * @param int $positions Number of positions to shift
+     * @return \GMP
+     */
+    public function leftShift(\GMP $number, $positions);
+
+    /**
+     * Returns the string representation of a returned value.
+     *
+     * @param \GMP $value
+     * @return int|string
+     */
+    public function toString(\GMP $value);
+
+    /**
+     * Converts an hexadecimal string to decimal.
+     *
+     * @param  string $hexString
+     * @return int|string
+     */
+    public function hexDec($hexString);
+
+    /**
+     * Converts a decimal string to hexadecimal.
+     *
+     * @param  int|string $decString
+     * @return int|string
+     */
+    public function decHex($decString);
+
+    /**
+     * Calculates the modular exponent of a number.
+     *
+     * @param \GMP $base
+     * @param \GMP $exponent
+     * @param \GMP $modulus
+     */
+    public function powmod(\GMP $base, \GMP $exponent, \GMP $modulus);
+
+    /**
+     * Checks whether a number is a prime.
+     *
+     * @param  \GMP $n
+     * @return boolean
+     */
+    public function isPrime(\GMP $n);
+
+    /**
+     * Gets the next known prime that is greater than a given prime.
+     *
+     * @param  \GMP $currentPrime
+     * @return \GMP
+     */
+    public function nextPrime(\GMP $currentPrime);
+
+    /**
+     * @param \GMP $a
+     * @param \GMP $m
+     * @return \GMP
+     */
+    public function inverseMod(\GMP $a, \GMP $m);
+
+    /**
+     * @param \GMP $a
+     * @param \GMP $p
+     * @return int
+     */
+    public function jacobi(\GMP $a, \GMP $p);
+
+    /**
+     * @param  \GMP $x
+     * @return string|null
+     */
+    public function intToString(\GMP $x);
+
+    /**
+     *
+     * @param  int|string $s
+     * @return \GMP
+     */
+    public function stringToInt($s);
+
+    /**
+     *
+     * @param  \GMP $m
+     * @return \GMP
+     */
+    public function digestInteger(\GMP $m);
+
+    /**
+     * @param  \GMP $a
+     * @param  \GMP $m
+     * @return \GMP
+     */
+    public function gcd2(\GMP $a, \GMP $m);
+
+    /**
+     * @param $value
+     * @param $fromBase
+     * @param $toBase
+     * @return int|string
+     */
+    public function baseConvert($value, $fromBase, $toBase);
+
+    /**
+     * @return NumberTheory
+     */
+    public function getNumberTheory();
+
+    /**
+     * @param \GMP $modulus
+     * @return ModularArithmetic
+     */
+    public function getModularArithmetic(\GMP $modulus);
+}

--- a/libs/TLS/Mdanter/Ecc/Math/MathAdapterFactory.php
+++ b/libs/TLS/Mdanter/Ecc/Math/MathAdapterFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Mdanter\Ecc\Math;
+
+class MathAdapterFactory
+{
+    private static $forcedAdapter = null;
+
+    /**
+     * @param GmpMathInterface $adapter
+     */
+    public static function forceAdapter(GmpMathInterface $adapter = null)
+    {
+        self::$forcedAdapter = $adapter;
+    }
+
+    /**
+     * @param bool $debug
+     * @return DebugDecorator|GmpMathInterface|null
+     */
+    public static function getAdapter($debug = false)
+    {
+        if (self::$forcedAdapter !== null) {
+            return self::$forcedAdapter;
+        }
+
+        $adapter = new GmpMath();
+
+        return self::wrapAdapter($adapter, (bool)$debug);
+    }
+
+    /**
+     * @param GmpMathInterface $adapter
+     * @param bool $debug
+     * @return DebugDecorator|GmpMathInterface
+     */
+    private static function wrapAdapter(GmpMathInterface $adapter, $debug)
+    {
+        if ($debug === true) {
+            return new DebugDecorator($adapter);
+        }
+
+        return $adapter;
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Math/ModularArithmetic.php
+++ b/libs/TLS/Mdanter/Ecc/Math/ModularArithmetic.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Mdanter\Ecc\Math;
+
+class ModularArithmetic
+{
+    /**
+     * @var GmpMathInterface
+     */
+    private $adapter;
+
+    /**
+     * @var \GMP
+     */
+    private $modulus;
+
+    /**
+     * @param GmpMathInterface $adapter
+     * @param \GMP $modulus
+     */
+    public function __construct(GmpMathInterface $adapter, \GMP $modulus)
+    {
+        $this->adapter = $adapter;
+        $this->modulus = $modulus;
+    }
+
+    /**
+     * @param \GMP $augend
+     * @param \GMP $addend
+     * @return \GMP
+     */
+    public function add(\GMP $augend, \GMP $addend)
+    {
+        return $this->adapter->mod($this->adapter->add($augend, $addend), $this->modulus);
+    }
+
+    /**
+     * @param \GMP $minuend
+     * @param \GMP $subtrahend
+     * @return \GMP
+     */
+    public function sub(\GMP $minuend, \GMP $subtrahend)
+    {
+        return $this->adapter->mod($this->adapter->sub($minuend, $subtrahend), $this->modulus);
+    }
+
+    /**
+     * @param \GMP $multiplier
+     * @param \GMP $muliplicand
+     * @return \GMP
+     */
+    public function mul(\GMP $multiplier, \GMP $muliplicand)
+    {
+        return $this->adapter->mod($this->adapter->mul($multiplier, $muliplicand), $this->modulus);
+    }
+
+    /**
+     * @param \GMP $dividend
+     * @param \GMP $divisor
+     * @return \GMP
+     */
+    public function div(\GMP $dividend, \GMP $divisor)
+    {
+        return $this->mul($dividend, $this->adapter->inverseMod($divisor, $this->modulus));
+    }
+
+    /**
+     * @param \GMP $base
+     * @param \GMP $exponent
+     * @return \GMP
+     */
+    public function pow(\GMP $base, \GMP $exponent)
+    {
+        return $this->adapter->powmod($base, $exponent, $this->modulus);
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Math/NumberTheory.php
+++ b/libs/TLS/Mdanter/Ecc/Math/NumberTheory.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace Mdanter\Ecc\Math;
+
+/***********************************************************************
+ * Copyright (C) 2012 Matyas Danter
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ ************************************************************************/
+
+/**
+ * Implementation of some number theoretic algorithms
+ *
+ * @author Matyas Danter
+ */
+
+/**
+ * Rewritten to take a MathAdaptor to handle different environments. Has
+ * some desireable functions for public key compression/recovery.
+ */
+class NumberTheory
+{
+    /**
+     * @var GmpMathInterface
+     */
+    protected $adapter;
+
+    /**
+     * @param GmpMathInterface $adapter
+     */
+    public function __construct(GmpMathInterface $adapter)
+    {
+        $this->adapter = $adapter;
+    }
+
+    /**
+     * @param \GMP[] $poly
+     * @param $polymod
+     * @param $p
+     * @return array
+     */
+    public function polynomialReduceMod($poly, $polymod, $p)
+    {
+        $adapter = $this->adapter;
+        $count_polymod = count($polymod);
+        if ($adapter->equals(end($polymod), gmp_init(1)) && $count_polymod > 1) {
+            $zero = gmp_init(0);
+            while (count($poly) >= $count_polymod) {
+                if (!$adapter->equals(end($poly), $zero)) {
+                    for ($i = 2; $i < $count_polymod + 1; $i++) {
+                        $poly[count($poly) - $i] =
+                            $adapter->mod(
+                                $adapter->sub(
+                                    $poly[count($poly) - $i],
+                                    $adapter->mul(
+                                        end($poly),
+                                        $polymod[$count_polymod - $i]
+                                    )
+                                ),
+                                $p
+                            );
+                    }
+                }
+
+                $poly = array_slice($poly, 0, count($poly) - 1);
+            }
+
+            return $poly;
+        }
+
+        throw new \InvalidArgumentException('Unable to calculate polynomialReduceMod');
+    }
+
+    /**
+     * @param $m1
+     * @param $m2
+     * @param $polymod
+     * @param $p
+     * @return array
+     */
+    public function polynomialMultiplyMod($m1, $m2, $polymod, $p)
+    {
+        $prod = [];
+        $cm1 = count($m1);
+        $cm2 = count($m2);
+        $zero = gmp_init(0, 10);
+
+        for ($i = 0; $i < $cm1; $i++) {
+            for ($j = 0; $j < $cm2; $j++) {
+                $index = $i + $j;
+                if (!isset($prod[$index])) {
+                    $prod[$index] = $zero;
+                }
+                $prod[$index] =
+                    $this->adapter->mod(
+                        $this->adapter->add(
+                            $prod[$index],
+                            $this->adapter->mul(
+                                $m1[$i],
+                                $m2[$j]
+                            )
+                        ),
+                        $p
+                    );
+            }
+        }
+
+        return $this->polynomialReduceMod($prod, $polymod, $p);
+    }
+
+    /**
+     * @param array $base
+     * @param \GMP $exponent
+     * @param array $polymod
+     * @param \GMP $p
+     * @return array|int
+     */
+    public function polynomialPowMod($base, \GMP $exponent, $polymod, \GMP $p)
+    {
+        $adapter = $this->adapter;
+        $zero = gmp_init(0, 10);
+        $one = gmp_init(1, 10);
+        $two = gmp_init(2, 10);
+
+        if ($adapter->cmp($exponent, $p) < 0) {
+            if ($adapter->equals($exponent, $zero)) {
+                return $one;
+            }
+
+            $G = $base;
+            $k = $exponent;
+
+            if ($adapter->equals($adapter->mod($k, $two), $one)) {
+                $s = $G;
+            } else {
+                $s = [$one];
+            }
+
+            while ($adapter->cmp($k, $one) > 0) {
+                $k = $adapter->div($k, $two);
+
+                $G = $this->polynomialMultiplyMod($G, $G, $polymod, $p);
+                if ($adapter->equals($adapter->mod($k, $two), $one)) {
+                    $s = $this->polynomialMultiplyMod($G, $s, $polymod, $p);
+                }
+            }
+
+            return $s;
+        }
+
+        throw new \InvalidArgumentException('Unable to calculate polynomialPowMod');
+    }
+
+    /**
+     * @param \GMP $a
+     * @param \GMP $p
+     * @return \GMP
+     */
+    public function squareRootModP(\GMP $a, \GMP $p)
+    {
+        $math = $this->adapter;
+        $zero = gmp_init(0, 10);
+        $one = gmp_init(1, 10);
+        $two = gmp_init(2, 10);
+        $four = gmp_init(4, 10);
+        $eight = gmp_init(8, 10);
+
+        $modMath = $math->getModularArithmetic($p);
+        if ($math->cmp($one, $p) < 0) {
+            if ($math->equals($a, $zero)) {
+                return $zero;
+            }
+
+            if ($math->equals($p, $two)) {
+                return $a;
+            }
+
+            $jac = $math->jacobi($a, $p);
+            if ($jac == -1) {
+                throw new \LogicException($math->toString($a) . " has no square root modulo " . $math->toString($p));
+            }
+
+            if ($math->equals($math->mod($p, $four), gmp_init(3, 10))) {
+                return $modMath->pow($a, $math->div($math->add($p, $one), $four));
+            }
+
+            if ($math->equals($math->mod($p, $eight), gmp_init(5, 10))) {
+                $d = $modMath->pow($a, $math->div($math->sub($p, $one), $four));
+                if ($math->equals($d, $one)) {
+                    return $modMath->pow($a, $math->div($math->add($p, gmp_init(3, 10)), $eight));
+                }
+
+                if ($math->equals($d, $math->sub($p, $one))) {
+                    return $modMath->mul(
+                        $math->mul(
+                            $two,
+                            $a
+                        ),
+                        $modMath->pow(
+                            $math->mul(
+                                $four,
+                                $a
+                            ),
+                            $math->div(
+                                $math->sub(
+                                    $p,
+                                    gmp_init(5, 10)
+                                ),
+                                $eight
+                            )
+                        )
+                    );
+                }
+                //shouldn't get here
+            }
+
+            for ($b = gmp_init(2, 10); $math->cmp($b, $p) < 0; $b = gmp_add($b, gmp_init(1, 10))) {
+                if ($math->jacobi(
+                        $math->sub(
+                            $math->mul($b, $b),
+                            $math->mul($four, $a)
+                        ),
+                        $p
+                    ) == -1
+                ) {
+                    $f = [$a, $math->sub($zero, $b), $one];
+
+                    $ff = $this->polynomialPowMod(
+                        [$zero, $one],
+                        $math->div(
+                            $math->add(
+                                $p,
+                                $one
+                            ),
+                            $two
+                        ),
+                        $f,
+                        $p
+                    );
+
+                    if ($math->equals($ff[1], $zero)) {
+                        return $ff[0];
+                    }
+                    // if we got here no b was found
+                }
+            }
+        }
+
+        throw new \InvalidArgumentException('Unable to calculate square root mod p!');
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Primitives/CurveFp.php
+++ b/libs/TLS/Mdanter/Ecc/Primitives/CurveFp.php
@@ -1,0 +1,239 @@
+<?php
+
+/***********************************************************************
+ * Copyright (C) 2012 Matyas Danter
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+
+namespace Mdanter\Ecc\Primitives;
+
+use Mdanter\Ecc\Math\GmpMathInterface;
+use Mdanter\Ecc\Math\ModularArithmetic;
+use Mdanter\Ecc\Random\RandomNumberGeneratorInterface;
+
+/**
+ * This class is a representation of an EC over a field modulo a prime number
+ *
+ * Important objectives for this class are:
+ * - Does the curve contain a point?
+ * - Comparison of two curves.
+ */
+class CurveFp implements CurveFpInterface
+{
+
+    /**
+     * @var CurveParameters
+     */
+    protected $parameters;
+
+    /**
+     *
+     * @var GmpMathInterface
+     */
+    protected $adapter = null;
+
+    /**
+     *
+     * @var ModularArithmetic
+     */
+    protected $modAdapter = null;
+
+    /**
+     * Constructor that sets up the instance variables.
+     *
+     * @param CurveParameters $parameters
+     * @param GmpMathInterface $adapter
+     */
+    public function __construct(CurveParameters $parameters, GmpMathInterface $adapter)
+    {
+        $this->parameters = $parameters;
+        $this->adapter = $adapter;
+        $this->modAdapter = new ModularArithmetic($this->adapter, $this->parameters->getPrime());
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\CurveFpInterface::getModAdapter()
+     */
+    public function getModAdapter()
+    {
+        return $this->modAdapter;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\CurveFpInterface::getPoint()
+     */
+    public function getPoint(\GMP $x, \GMP $y, \GMP $order = null)
+    {
+        return new Point($this->adapter, $this, $x, $y, $order);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\CurveFpInterface::getInfinity()
+     */
+    public function getInfinity()
+    {
+        return new Point($this->adapter, $this, gmp_init(0, 10), gmp_init(0, 10), null, true);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\CurveFpInterface::getGenerator()
+     */
+    public function getGenerator(\GMP $x, \GMP $y, \GMP $order, RandomNumberGeneratorInterface $randomGenerator = null)
+    {
+        return new GeneratorPoint($this->adapter, $this, $x, $y, $order, $randomGenerator);
+    }
+
+    /**
+     * @param bool $wasOdd
+     * @param \GMP $xCoord
+     * @return \GMP
+     */
+    public function recoverYfromX($wasOdd, \GMP $xCoord)
+    {
+        $math = $this->adapter;
+        $prime = $this->getPrime();
+
+        $root = $this->adapter->getNumberTheory()->squareRootModP(
+            $math->add(
+                $math->add(
+                    $this->modAdapter->pow($xCoord, gmp_init(3, 10)),
+                    $math->mul($this->getA(), $xCoord)
+                ),
+                $this->getB()
+            ),
+            $prime
+        );
+
+        if ($math->equals($math->mod($root, gmp_init(2, 10)), gmp_init(1)) === $wasOdd) {
+            return $root;
+        } else {
+            return $math->sub($prime, $root);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\CurveFpInterface::contains()
+     */
+    public function contains(\GMP $x, \GMP $y)
+    {
+        $math = $this->adapter;
+
+        $eq_zero = $math->equals(
+            $this->modAdapter->sub(
+                $math->pow($y, 2),
+                $math->add(
+                    $math->add(
+                        $math->pow($x, 3),
+                        $math->mul($this->getA(), $x)
+                    ),
+                    $this->getB()
+                )
+            ),
+            gmp_init(0, 10)
+        );
+
+        return $eq_zero;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\CurveFpInterface::getA()
+     */
+    public function getA()
+    {
+        return $this->parameters->getA();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\CurveFpInterface::getB()
+     */
+    public function getB()
+    {
+        return $this->parameters->getB();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\CurveFpInterface::getPrime()
+     */
+    public function getPrime()
+    {
+        return $this->parameters->getPrime();
+    }
+
+    /**
+     * @return int
+     */
+    public function getSize()
+    {
+        return $this->parameters->getSize();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\CurveFpInterface::cmp()
+     */
+    public function cmp(CurveFpInterface $other)
+    {
+        $math = $this->adapter;
+
+        $equal = $math->equals($this->getA(), $other->getA());
+        $equal &= $math->equals($this->getB(), $other->getB());
+        $equal &= $math->equals($this->getPrime(), $other->getPrime());
+
+        return ($equal) ? 0 : 1;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\CurveFpInterface::equals()
+     */
+    public function equals(CurveFpInterface $other)
+    {
+        return $this->cmp($other) == 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\CurveFpInterface::__toString()
+     */
+    public function __toString()
+    {
+        return 'curve(' . $this->adapter->toString($this->getA()) . ', ' . $this->adapter->toString($this->getB()) . ', ' . $this->adapter->toString($this->getPrime()) . ')';
+    }
+
+    /**
+     * @return array
+     */
+    public function __debugInfo()
+    {
+        return [
+            'a' => $this->adapter->toString($this->getA()),
+            'b' => $this->adapter->toString($this->getB()),
+            'prime' => $this->adapter->toString($this->getPrime())
+        ];
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Primitives/CurveFpInterface.php
+++ b/libs/TLS/Mdanter/Ecc/Primitives/CurveFpInterface.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Mdanter\Ecc\Primitives;
+
+use Mdanter\Ecc\Math\ModularArithmetic;
+use Mdanter\Ecc\Random\RandomNumberGeneratorInterface;
+
+/**
+ * *********************************************************************
+ * Copyright (C) 2012 Matyas Danter
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * ***********************************************************************
+ */
+
+/**
+ * This is the contract for implementing CurveFp (EC prime finite-field).
+ */
+interface CurveFpInterface
+{
+
+    /**
+     * Returns a modular arithmetic adapter.
+     *
+     * @return ModularArithmetic
+     */
+    public function getModAdapter();
+
+    /**
+     * Returns the point identified by given coordinates.
+     *
+     * @param  \GMP $x
+     * @param  \GMP $y
+     * @param  \GMP $order
+     * @return PointInterface
+     */
+    public function getPoint(\GMP $x, \GMP $y, \GMP $order = null);
+
+    /**
+     * @param bool $wasOdd
+     * @param \GMP $x
+     * @return \GMP
+     */
+    public function recoverYfromX($wasOdd, \GMP $x);
+
+    /**
+     * Returns a point representing infinity on the curve.
+     *
+     * @return PointInterface
+     */
+    public function getInfinity();
+
+    /**
+     *
+     * @param  \GMP $x
+     * @param  \GMP $y
+     * @param  \GMP $order
+     * @param  RandomNumberGeneratorInterface $randomGenerator
+     * @return GeneratorPoint
+     */
+    public function getGenerator(\GMP $x, \GMP $y, \GMP $order, RandomNumberGeneratorInterface $randomGenerator = null);
+
+    /**
+     * Checks whether the curve contains the given coordinates.
+     *
+     * @param  \GMP $x
+     * @param  \GMP $y
+     * @return bool
+     */
+    public function contains(\GMP $x, \GMP $y);
+
+    /**
+     * Returns the a parameter of the curve.
+     *
+     * @return \GMP
+     */
+    public function getA();
+
+    /**
+     * Returns the b parameter of the curve.
+     *
+     * @return \GMP
+     */
+    public function getB();
+
+    /**
+     * Returns the prime associated with the curve.
+     *
+     * @return \GMP
+     */
+    public function getPrime();
+
+    /**
+     * @return int
+     */
+    public function getSize();
+
+    /**
+     * Compares the curve to another.
+     *
+     * @param  CurveFpInterface $other
+     * @return int              < 0 if $this < $other, 0 if $other == $this, > 0 if $this > $other
+     */
+    public function cmp(CurveFpInterface $other);
+
+    /**
+     * Checks whether the curve is equal to another.
+     *
+     * @param  CurveFpInterface $other
+     * @return bool
+     */
+    public function equals(CurveFpInterface $other);
+
+    /**
+     * Return string representation of curve for debugging
+     *
+     * @return string
+     */
+    public function __toString();
+}

--- a/libs/TLS/Mdanter/Ecc/Primitives/CurveParameters.php
+++ b/libs/TLS/Mdanter/Ecc/Primitives/CurveParameters.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Mdanter\Ecc\Primitives;
+
+class CurveParameters
+{
+    /**
+     * Elliptic curve over the field of integers modulo a prime.
+     *
+     * @var \GMP
+     */
+    protected $a;
+
+    /**
+     *
+     * @var \GMP
+     */
+    protected $b;
+
+    /**
+     *
+     * @var \GMP
+     */
+    protected $prime;
+
+    /**
+     * Binary length of keys associated with these curve parameters
+     *
+     * @var int
+     */
+    protected $size;
+
+    /**
+     * @param int $size
+     * @param \GMP $prime
+     * @param \GMP $a
+     * @param \GMP $b
+     */
+    public function __construct($size, \GMP $prime, \GMP $a, \GMP $b)
+    {
+        $this->size = $size;
+        $this->prime = $prime;
+        $this->a = $a;
+        $this->b = $b;
+    }
+
+    /**
+     * @return \GMP
+     */
+    public function getA()
+    {
+        return $this->a;
+    }
+
+    /**
+     * @return \GMP
+     */
+    public function getB()
+    {
+        return $this->b;
+    }
+
+    /**
+     * @return \GMP
+     */
+    public function getPrime()
+    {
+        return $this->prime;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSize()
+    {
+        return $this->size;
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Primitives/GeneratorPoint.php
+++ b/libs/TLS/Mdanter/Ecc/Primitives/GeneratorPoint.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Mdanter\Ecc\Primitives;
+
+use Mdanter\Ecc\Math\GmpMathInterface;
+use Mdanter\Ecc\Crypto\Key\PrivateKey;
+use Mdanter\Ecc\Crypto\Key\PublicKey;
+use Mdanter\Ecc\Random\RandomGeneratorFactory;
+use Mdanter\Ecc\Random\RandomNumberGeneratorInterface;
+
+/**
+ * Curve point from which public and private keys can be derived.
+ */
+class GeneratorPoint extends Point
+{
+    /**
+     * @var \Mdanter\Ecc\Random\DebugDecorator|RandomNumberGeneratorInterface|null
+     */
+    private $generator;
+
+    /**
+     * @param GmpMathInterface $adapter
+     * @param CurveFpInterface $curve
+     * @param \GMP $x
+     * @param \GMP $y
+     * @param \GMP $order
+     * @param RandomNumberGeneratorInterface $generator
+     */
+    public function __construct(
+        GmpMathInterface $adapter,
+        CurveFpInterface $curve,
+        \GMP $x,
+        \GMP $y,
+        \GMP $order,
+        RandomNumberGeneratorInterface $generator = null
+    )
+    {
+        $this->generator = $generator ?: RandomGeneratorFactory::getRandomGenerator();
+        parent::__construct($adapter, $curve, $x, $y, $order);
+    }
+
+    /**
+     * Verifies validity of given coordinates against the current point and its point.
+     *
+     * @todo   Check if really necessary here (only used for testing in lib)
+     * @param  \GMP $x
+     * @param  \GMP $y
+     * @return boolean
+     */
+    public function isValid(\GMP $x, \GMP $y)
+    {
+        $math = $this->getAdapter();
+
+        $n = $this->getOrder();
+        $zero = gmp_init(0, 10);
+        $curve = $this->getCurve();
+
+        if ($math->cmp($x, $zero) < 0 || $math->cmp($n, $x) <= 0 || $math->cmp($y, $zero) < 0 || $math->cmp($n, $y) <= 0) {
+            return false;
+        }
+
+        if (!$curve->contains($x, $y)) {
+            return false;
+        }
+
+        $point = $curve->getPoint($x, $y)->mul($n);
+
+        if (!$point->isInfinity()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return PrivateKey
+     */
+    public function createPrivateKey()
+    {
+        $secret = $this->generator->generate($this->getOrder());
+
+        return new PrivateKey($this->getAdapter(), $this, $secret);
+    }
+
+    /**
+     * @param \GMP $x
+     * @param \GMP $y
+     * @param \GMP $order
+     * @return PublicKey
+     */
+    public function getPublicKeyFrom(\GMP $x, \GMP $y, \GMP $order = null)
+    {
+        $pubPoint = $this->getCurve()->getPoint($x, $y, $order);
+        return new PublicKey($this->getAdapter(), $this, $pubPoint);
+    }
+
+    /**
+     * @param \GMP $secretMultiplier
+     * @return PrivateKey
+     */
+    public function getPrivateKeyFrom(\GMP $secretMultiplier)
+    {
+        return new PrivateKey($this->getAdapter(), $this, $secretMultiplier);
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Primitives/Point.php
+++ b/libs/TLS/Mdanter/Ecc/Primitives/Point.php
@@ -1,0 +1,411 @@
+<?php
+
+namespace Mdanter\Ecc\Primitives;
+
+use Mdanter\Ecc\Math\GmpMathInterface;
+use Mdanter\Ecc\Math\ModularArithmetic;
+use Mdanter\Ecc\Util\BinaryString;
+
+/**
+ * *********************************************************************
+ * Copyright (C) 2012 Matyas Danter
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * ***********************************************************************
+ */
+
+/**
+ * This class is where the elliptic curve arithmetic takes place.
+ * The important methods are:
+ * - add: adds two points according to ec arithmetic
+ * - double: doubles a point on the ec field mod p
+ * - mul: uses double and add to achieve multiplication The rest of the methods are there for supporting the ones above.
+ */
+class Point implements PointInterface
+{
+    /**
+     * @var CurveFpInterface
+     */
+    private $curve;
+
+    /**
+     * @var GmpMathInterface
+     */
+    private $adapter;
+
+    /**
+     * @var ModularArithmetic
+     */
+    private $modAdapter;
+
+    /**
+     * @var \GMP
+     */
+    private $x;
+
+    /**
+     * @var \GMP
+     */
+    private $y;
+
+    /**
+     * @var \GMP
+     */
+    private $order;
+
+    /**
+     * @var bool
+     */
+    private $infinity = false;
+
+    /**
+     * Initialize a new instance
+     *
+     * @param GmpMathInterface $adapter
+     * @param CurveFpInterface $curve
+     * @param \GMP $x
+     * @param \GMP $y
+     * @param \GMP $order
+     * @param bool $infinity
+     *
+     * @throws \RuntimeException    when either the curve does not contain the given coordinates or
+     *                                      when order is not null and P(x, y) * order is not equal to infinity.
+     */
+    public function __construct(GmpMathInterface $adapter, CurveFpInterface $curve, \GMP $x, \GMP $y, \GMP $order = null, $infinity = false)
+    {
+        $this->adapter = $adapter;
+        $this->modAdapter = $curve->getModAdapter();
+        $this->curve = $curve;
+        $this->x = $x;
+        $this->y = $y;
+        $this->order = $order !== null ? $order : gmp_init(0, 10);
+        $this->infinity = (bool)$infinity;
+        if (!$infinity && !$curve->contains($x, $y)) {
+            throw new \RuntimeException("Curve " . $curve . " does not contain point (" . $adapter->toString($x) . ", " . $adapter->toString($y) . ")");
+        }
+
+        if (!is_null($order)) {
+            $mul = $this->mul($order);
+            if (!$mul->isInfinity()) {
+                throw new \RuntimeException("SELF * ORDER MUST EQUAL INFINITY. (" . (string)$mul . " found instead)");
+            }
+        }
+    }
+
+    /**
+     * @return GmpMathInterface
+     */
+    public function getAdapter()
+    {
+        return $this->adapter;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\PointInterface::isInfinity()
+     */
+    public function isInfinity()
+    {
+        return (bool)$this->infinity;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\PointInterface::getCurve()
+     */
+    public function getCurve()
+    {
+        return $this->curve;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\PointInterface::getOrder()
+     */
+    public function getOrder()
+    {
+        return $this->order;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\PointInterface::getX()
+     */
+    public function getX()
+    {
+        return $this->x;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\PointInterface::getY()
+     */
+    public function getY()
+    {
+        return $this->y;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\PointInterface::add()
+     * @return self
+     */
+    public function add(PointInterface $addend)
+    {
+        if (!$this->curve->equals($addend->getCurve())) {
+            throw new \RuntimeException("The Elliptic Curves do not match.");
+        }
+
+        if ($addend->isInfinity()) {
+            return clone $this;
+        }
+
+        if ($this->isInfinity()) {
+            return clone $addend;
+        }
+
+        $math = $this->adapter;
+        $modMath = $this->modAdapter;
+
+        if ($math->equals($addend->getX(), $this->x)) {
+            if ($math->equals($addend->getY(), $this->y)) {
+                return $this->getDouble();
+            } else {
+                return $this->curve->getInfinity();
+            }
+        }
+
+        $slope = $modMath->div(
+            $math->sub($addend->getY(), $this->y),
+            $math->sub($addend->getX(), $this->x)
+        );
+
+        $xR = $modMath->sub(
+            $math->sub($math->pow($slope, 2), $this->x),
+            $addend->getX()
+        );
+
+        $yR = $modMath->sub(
+            $math->mul($slope, $math->sub($this->x, $xR)),
+            $this->y
+        );
+
+        return $this->curve->getPoint($xR, $yR, $this->order);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\PointInterface::cmp()
+     */
+    public function cmp(PointInterface $other)
+    {
+        if ($other->isInfinity() && $this->isInfinity()) {
+            return 0;
+        }
+
+        if ($other->isInfinity() || $this->isInfinity()) {
+            return 1;
+        }
+
+        $math = $this->adapter;
+        $equal = ($math->equals($this->x, $other->getX()));
+        $equal &= ($math->equals($this->y, $other->getY()));
+        $equal &= $this->isInfinity() == $other->isInfinity();
+        $equal &= $this->curve->equals($other->getCurve());
+
+        if ($equal) {
+            return 0;
+        }
+
+        return 1;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\PointInterface::equals()
+     */
+    public function equals(PointInterface $other)
+    {
+        return $this->cmp($other) == 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\PointInterface::mul()
+     */
+    public function mul(\GMP $n)
+    {
+        if ($this->isInfinity()) {
+            return $this->curve->getInfinity();
+        }
+
+        $zero = gmp_init(0, 10);
+        if ($this->adapter->cmp($this->order, $zero) > 0) {
+            $n = $this->adapter->mod($n, $this->order);
+        }
+
+        if ($this->adapter->equals($n, $zero)) {
+            return $this->curve->getInfinity();
+        }
+
+        /** @var Point[] $r */
+        $r = [
+            $this->curve->getInfinity(),
+            clone $this
+        ];
+
+        $k = $this->curve->getSize();
+        $n = str_pad($this->adapter->baseConvert($this->adapter->toString($n), 10, 2), $k, '0', STR_PAD_LEFT);
+
+        for ($i = 0; $i < $k; $i++) {
+            $j = $n[$i];
+
+            $this->cswap($r[0], $r[1], $j ^ 1);
+
+            $r[0] = $r[0]->add($r[1]);
+            $r[1] = $r[1]->getDouble();
+
+            $this->cswap($r[0], $r[1], $j ^ 1);
+        }
+
+        $r[0]->validate();
+
+        return $r[0];
+    }
+
+    /**
+     * @param Point $a
+     * @param Point $b
+     * @param int $cond
+     */
+    private function cswap(self $a, self $b, $cond)
+    {
+        $this->cswapValue($a->x, $b->x, $cond);
+        $this->cswapValue($a->y, $b->y, $cond);
+        $this->cswapValue($a->order, $b->order, $cond);
+        $this->cswapValue($a->infinity, $b->infinity, $cond);
+    }
+
+    /**
+     * @param $a
+     * @param $b
+     * @param $cond
+     */
+    public function cswapValue(& $a, & $b, $cond)
+    {
+        $isGMP = is_object($a) && $a instanceof \GMP;
+
+        $sa = $isGMP ? $a : gmp_init(intval($a), 10);
+        $sb = $isGMP ? $b : gmp_init(intval($b), 10);
+        $size = max(BinaryString::length(gmp_strval($sa, 2)), BinaryString::length(gmp_strval($sb, 2)));
+
+        $mask = 1 - intval($cond);
+        $mask = str_pad('', $size, $mask, STR_PAD_LEFT);
+        $mask = gmp_init($mask, 2);
+
+        $taA = $this->adapter->bitwiseAnd($sa, $mask);
+        $taB = $this->adapter->bitwiseAnd($sb, $mask);
+
+        $sa = $this->adapter->bitwiseXor($this->adapter->bitwiseXor($sa, $sb), $taB);
+        $sb = $this->adapter->bitwiseXor($this->adapter->bitwiseXor($sa, $sb), $taA);
+        $sa = $this->adapter->bitwiseXor($this->adapter->bitwiseXor($sa, $sb), $taB);
+
+        $a = $isGMP ? $sa : (bool)gmp_strval($sa, 10);
+        $b = $isGMP ? $sb : (bool)gmp_strval($sb, 10);
+    }
+
+    /**
+     *
+     */
+    private function validate()
+    {
+        if (!$this->infinity && !$this->curve->contains($this->x, $this->y)) {
+            throw new \RuntimeException('Invalid point');
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\PointInterface::getDouble()
+     * @return self
+     */
+    public function getDouble()
+    {
+        if ($this->isInfinity()) {
+            return $this->curve->getInfinity();
+        }
+
+        $math = $this->adapter;
+        $modMath = $this->modAdapter;
+
+        $a = $this->curve->getA();
+        $threeX2 = $math->mul(gmp_init(3, 10), $math->pow($this->x, 2));
+
+        $tangent = $modMath->div(
+            $math->add($threeX2, $a),
+            $math->mul(gmp_init(2, 10), $this->y)
+        );
+
+        $x3 = $modMath->sub(
+            $math->pow($tangent, 2),
+            $math->mul(gmp_init(2, 10), $this->x)
+        );
+
+        $y3 = $modMath->sub(
+            $math->mul($tangent, $math->sub($this->x, $x3)),
+            $this->y
+        );
+
+        return $this->curve->getPoint($x3, $y3, $this->order);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\PointInterface::__toString()
+     */
+    public function __toString()
+    {
+        if ($this->infinity) {
+            return '[ (infinity) on ' . (string)$this->curve . ' ]';
+        }
+
+        return "[ (" . $this->adapter->toString($this->x) . "," . $this->adapter->toString($this->y) . ') on ' . (string)$this->curve . ' ]';
+    }
+
+    /**
+     * @return array
+     */
+    public function __debugInfo()
+    {
+        $info = [
+            'x' => $this->adapter->toString($this->x),
+            'y' => $this->adapter->toString($this->y),
+            'z' => $this->adapter->toString($this->order),
+            'curve' => $this->curve
+        ];
+
+        if ($this->infinity) {
+            $info['x'] = 'inf (' . $info['x'] . ')';
+            $info['y'] = 'inf (' . $info['y'] . ')';
+            $info['z'] = 'inf (' . $info['z'] . ')';
+        }
+
+        return $info;
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Primitives/PointInterface.php
+++ b/libs/TLS/Mdanter/Ecc/Primitives/PointInterface.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Mdanter\Ecc\Primitives;
+
+/**
+ * *********************************************************************
+ * Copyright (C) 2012 Matyas Danter
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * ***********************************************************************
+ */
+
+/**
+ * This is the contract for implementing Point, which encapsulates entities
+ * and operations over the points on the Elliptic Curve. Implementations must be immutable.
+ *
+ * Implementors must be wary of the special "Infinity" implementation, which breaks LSP, and should always
+ * be checked against (and properly handled) when receiving a PointInterface as an argument or when a method indicates it can
+ * return infinity.
+ *
+ * @todo Fix LSP break (possibly derive an extra interface, FinitePointInterface from current one, and move
+ * coordinate-related ops to sub-interface).
+ */
+interface PointInterface
+{
+
+    /**
+     * Returns true if instance is an non-finite point.
+     */
+    public function isInfinity();
+
+    /**
+     * Adds another point to the current one and returns the resulting point.
+     *
+     * @param  PointInterface $addend
+     * @return PointInterface
+     */
+    public function add(PointInterface $addend);
+
+    /**
+     * Compares the current instance to another point.
+     *
+     * @param  PointInterface $other
+     * @return int|string              A number different than 0 when current instance is less than the given point, 0 when they are equal.
+     */
+    public function cmp(PointInterface $other);
+
+    /**
+     * Checks whether the current instance is equal to the given point.
+     *
+     * @param  PointInterface $other
+     * @return bool                    true when points are equal, false otherwise.
+     */
+    public function equals(PointInterface $other);
+
+    /**
+     * Multiplies the point by a scalar value and returns the resulting point.
+     *
+     * @param  \GMP $multiplier
+     * @return PointInterface
+     */
+    public function mul(\GMP $multiplier);
+
+    /**
+     * Returns the curve to which the point belongs.
+     *
+     * @return CurveFpInterface
+     */
+    public function getCurve();
+
+    /**
+     * Doubles the current point and returns the resulting point.
+     *
+     * @return PointInterface
+     */
+    public function getDouble();
+
+    /**
+     * Returns the order of the point.
+     *
+     * @return \GMP
+     */
+    public function getOrder();
+
+    /**
+     * Returns the X coordinate of the point.
+     *
+     * @return \GMP
+     */
+    public function getX();
+
+    /**
+     * Returns the Y coordinate of the point.
+     *
+     * @return \GMP
+     */
+    public function getY();
+
+    /**
+     * Returns the string representation of the point.
+     *
+     * @return string
+     */
+    public function __toString();
+}

--- a/libs/TLS/Mdanter/Ecc/Random/DebugDecorator.php
+++ b/libs/TLS/Mdanter/Ecc/Random/DebugDecorator.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Mdanter\Ecc\Random;
+
+class DebugDecorator implements RandomNumberGeneratorInterface
+{
+    /**
+     * @var RandomNumberGeneratorInterface
+     */
+    private $generator;
+
+    /**
+     * @var string
+     */
+    private $generatorName;
+
+    /**
+     * @param RandomNumberGeneratorInterface $generator
+     * @param string $name
+     */
+    public function __construct(RandomNumberGeneratorInterface $generator, $name)
+    {
+        $this->generator = $generator;
+        $this->generatorName = $name;
+    }
+
+    /**
+     * @param \GMP $max
+     * @return \GMP
+     */
+    public function generate(\GMP $max)
+    {
+        echo $this->generatorName . '::rand() = ';
+
+        $result = $this->generator->generate($max);
+
+        echo gmp_strval($result, 10) . PHP_EOL;
+
+        return $result;
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Random/HmacRandomNumberGenerator.php
+++ b/libs/TLS/Mdanter/Ecc/Random/HmacRandomNumberGenerator.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Mdanter\Ecc\Random;
+
+use Mdanter\Ecc\Crypto\Key\PrivateKeyInterface;
+use Mdanter\Ecc\Math\GmpMathInterface;
+use Mdanter\Ecc\Util\BinaryString;
+use Mdanter\Ecc\Util\NumberSize;
+
+class HmacRandomNumberGenerator implements RandomNumberGeneratorInterface
+{
+    /**
+     * @var GmpMathInterface
+     */
+    private $math;
+
+    /**
+     * @var string
+     */
+    private $algorithm;
+
+    /**
+     * @var PrivateKeyInterface
+     */
+    private $privateKey;
+
+    /**
+     * @var \GMP
+     */
+    private $messageHash;
+
+    /**
+     * @var array
+     */
+    private $algSize = [
+        'sha1' => 160,
+        'sha224' => 224,
+        'sha256' => 256,
+        'sha384' => 385,
+        'sha512' => 512
+    ];
+
+    /**
+     * Hmac constructor.
+     * @param GmpMathInterface $math
+     * @param PrivateKeyInterface $privateKey
+     * @param \GMP $messageHash - decimal hash of the message (*may* be truncated)
+     * @param string $algorithm - hashing algorithm
+     */
+    public function __construct(GmpMathInterface $math, PrivateKeyInterface $privateKey, \GMP $messageHash, $algorithm)
+    {
+        if (!isset($this->algSize[$algorithm])) {
+            throw new \InvalidArgumentException('Unsupported hashing algorithm');
+        }
+
+        $this->math = $math;
+        $this->algorithm = $algorithm;
+        $this->privateKey = $privateKey;
+        $this->messageHash = $messageHash;
+    }
+
+    /**
+     * @param string $bits - binary string of bits
+     * @param \GMP $qlen - length of q in bits
+     * @return \GMP
+     */
+    public function bits2int($bits, $qlen)
+    {
+        $vlen = gmp_init(BinaryString::length($bits) * 8, 10);
+        $hex = bin2hex($bits);
+        $v = gmp_init($hex, 16);
+
+        if ($this->math->cmp($vlen, $qlen) > 0) {
+            $v = $this->math->rightShift($v, $this->math->toString($this->math->sub($vlen, $qlen)));
+        }
+
+        return $v;
+    }
+
+    /**
+     * @param \GMP $int
+     * @param \GMP $rlen - rounded octet length
+     * @return string
+     */
+    public function int2octets(\GMP $int, \GMP $rlen)
+    {
+        $out = pack("H*", $this->math->decHex(gmp_strval($int, 10)));
+        $length = gmp_init(BinaryString::length($out), 10);
+        if ($this->math->cmp($length, $rlen) < 0) {
+            return str_pad('', $this->math->toString($this->math->sub($rlen, $length)), "\x00") . $out;
+        }
+
+        if ($this->math->cmp($length, $rlen) > 0) {
+            return BinaryString::substring($out, 0, $this->math->toString($rlen));
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param string $algorithm
+     * @return int
+     */
+    private function getHashLength($algorithm)
+    {
+        return $this->algSize[$algorithm];
+    }
+
+    /**
+     * @param \GMP $q
+     * @return \GMP
+     */
+    public function generate(\GMP $q)
+    {
+        $qlen = gmp_init(NumberSize::bnNumBits($this->math, $q), 10);
+        $rlen = $this->math->rightShift($this->math->add($qlen, gmp_init(7, 10)), 3);
+        $hlen = $this->getHashLength($this->algorithm);
+        $bx = $this->int2octets($this->privateKey->getSecret(), $rlen) . $this->int2octets($this->messageHash, $rlen);
+
+        $v = str_pad('', $hlen / 8, "\x01", STR_PAD_LEFT);
+        $k = str_pad('', $hlen / 8, "\x00", STR_PAD_LEFT);
+
+        $k = hash_hmac($this->algorithm, $v . "\x00" . $bx, $k, true);
+        $v = hash_hmac($this->algorithm, $v, $k, true);
+
+        $k = hash_hmac($this->algorithm, $v . "\x01" . $bx, $k, true);
+        $v = hash_hmac($this->algorithm, $v, $k, true);
+
+        $t = '';
+        for (; ;) {
+            $toff = gmp_init(0, 10);
+            while ($this->math->cmp($toff, $rlen) < 0) {
+                $v = hash_hmac($this->algorithm, $v, $k, true);
+
+                $cc = min(BinaryString::length($v), gmp_strval(gmp_sub($rlen, $toff), 10));
+                $t .= BinaryString::substring($v, 0, $cc);
+                $toff = gmp_add($toff, $cc);
+            }
+
+            $k = $this->bits2int($t, $qlen);
+            if ($this->math->cmp($k, gmp_init(0, 10)) > 0 && $this->math->cmp($k, $q) < 0) {
+                return $k;
+            }
+
+            $k = hash_hmac($this->algorithm, $v . "\x00", $k, true);
+            $v = hash_hmac($this->algorithm, $v, $k, true);
+        }
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Random/RandomGeneratorFactory.php
+++ b/libs/TLS/Mdanter/Ecc/Random/RandomGeneratorFactory.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Mdanter\Ecc\Random;
+
+use Mdanter\Ecc\Crypto\Key\PrivateKeyInterface;
+
+use Mdanter\Ecc\Math\MathAdapterFactory;
+
+class RandomGeneratorFactory
+{
+    /**
+     * @param bool $debug
+     * @return DebugDecorator|RandomNumberGeneratorInterface|null
+     */
+    public static function getRandomGenerator($debug = false)
+    {
+        return self::wrapAdapter(
+            new RandomNumberGenerator(
+                MathAdapterFactory::getAdapter($debug)
+            ),
+            'random_bytes',
+            $debug
+        );
+    }
+
+    /**
+     * @param PrivateKeyInterface $privateKey
+     * @param \GMP $messageHash
+     * @param string $algo
+     * @param bool $debug
+     * @return DebugDecorator|RandomNumberGeneratorInterface
+     */
+    public static function getHmacRandomGenerator(PrivateKeyInterface $privateKey, \GMP $messageHash, $algo, $debug = false)
+    {
+        return self::wrapAdapter(
+            new HmacRandomNumberGenerator(
+                MathAdapterFactory::getAdapter($debug),
+                $privateKey,
+                $messageHash,
+                $algo
+            ),
+            'rfc6979',
+            $debug
+        );
+    }
+
+    /**
+     * @param RandomNumberGeneratorInterface $generator
+     * @param $name
+     * @param bool $debug
+     * @return DebugDecorator|RandomNumberGeneratorInterface
+     */
+    private static function wrapAdapter(RandomNumberGeneratorInterface $generator, $name, $debug = false)
+    {
+        if ($debug === true) {
+            return new DebugDecorator($generator, $name);
+        }
+
+        return $generator;
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Random/RandomNumberGenerator.php
+++ b/libs/TLS/Mdanter/Ecc/Random/RandomNumberGenerator.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Mdanter\Ecc\Random;
+
+use Mdanter\Ecc\Math\GmpMathInterface;
+use Mdanter\Ecc\Util\NumberSize;
+
+class RandomNumberGenerator implements RandomNumberGeneratorInterface
+{
+    /**
+     * @var GmpMathInterface
+     */
+    private $adapter;
+
+    /**
+     * RandomNumberGenerator constructor.
+     * @param GmpMathInterface $adapter
+     */
+    public function __construct(GmpMathInterface $adapter)
+    {
+        $this->adapter = $adapter;
+    }
+
+    /**
+     * @param \GMP $max
+     * @return \GMP
+     */
+    public function generate(\GMP $max)
+    {
+        $numBits = NumberSize::bnNumBits($this->adapter, $max);
+        $numBytes = ceil($numBits / 8);
+
+        // Generate an integer of size >= $numBits
+        //$bytes = random_bytes($numBytes);
+        $bytes = openssl_random_pseudo_bytes($numBytes);
+        $value = $this->adapter->stringToInt($bytes);
+
+        $mask = gmp_sub(gmp_pow(2, $numBits), 1);
+        $integer = gmp_and($value, $mask);
+
+        return $integer;
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Random/RandomNumberGeneratorInterface.php
+++ b/libs/TLS/Mdanter/Ecc/Random/RandomNumberGeneratorInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mdanter\Ecc\Random;
+
+interface RandomNumberGeneratorInterface
+{
+    /**
+     * Generate a random number between 0 and the specified upper boundary.
+     *
+     * @param \GMP $max Upper boundary, inclusive
+     */
+    public function generate(\GMP $max);
+}

--- a/libs/TLS/Mdanter/Ecc/Serializer/Point/CompressedPointSerializer.php
+++ b/libs/TLS/Mdanter/Ecc/Serializer/Point/CompressedPointSerializer.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Mdanter\Ecc\Serializer\Point;
+
+use Mdanter\Ecc\Math\GmpMathInterface;
+use Mdanter\Ecc\Primitives\CurveFpInterface;
+use Mdanter\Ecc\Primitives\PointInterface;
+use Mdanter\Ecc\Serializer\Util\CurveOidMapper;
+
+class CompressedPointSerializer implements PointSerializerInterface
+{
+    /**
+     * @var GmpMathInterface
+     */
+    private $adapter;
+
+    /**
+     * @var \Mdanter\Ecc\Math\NumberTheory
+     */
+    private $theory;
+
+    /**
+     * CompressedPointSerializer constructor.
+     * @param GmpMathInterface $adapter
+     */
+    public function __construct(GmpMathInterface $adapter)
+    {
+        $this->adapter = $adapter;
+        $this->theory = $adapter->getNumberTheory();
+    }
+
+    /**
+     * @param PointInterface $point
+     * @return string
+     */
+    public function getPrefix(PointInterface $point)
+    {
+        if ($this->adapter->equals($this->adapter->mod($point->getY(), gmp_init(2, 10)), gmp_init(0))) {
+            return '02';
+        } else {
+            return '03';
+        }
+    }
+
+    /**
+     * @param PointInterface $point
+     * @return string
+     */
+    public function serialize(PointInterface $point)
+    {
+        $length = CurveOidMapper::getByteSize($point->getCurve()) * 2;
+
+        $hexString = $this->getPrefix($point);
+        $hexString .= str_pad(gmp_strval($point->getX(), 16), $length, '0', STR_PAD_LEFT);
+
+        return $hexString;
+    }
+
+    /**
+     * @param CurveFpInterface $curve
+     * @param string $data - hex serialized compressed point
+     * @return PointInterface
+     */
+    public function unserialize(CurveFpInterface $curve, $data)
+    {
+        $prefix = substr($data, 0, 2);
+        if ($prefix !== '03' && $prefix !== '02') {
+            throw new \InvalidArgumentException('Invalid data: only compressed keys are supported.');
+        }
+
+        $x = gmp_init(substr($data, 2), 16);
+        $y = $curve->recoverYfromX($prefix === '03', $x);
+
+        return $curve->getPoint($x, $y);
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Serializer/Point/PointSerializerInterface.php
+++ b/libs/TLS/Mdanter/Ecc/Serializer/Point/PointSerializerInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Mdanter\Ecc\Serializer\Point;
+
+use Mdanter\Ecc\Primitives\PointInterface;
+use Mdanter\Ecc\Primitives\CurveFpInterface;
+
+interface PointSerializerInterface
+{
+    /**
+     *
+     * @param  PointInterface $point
+     * @return string
+     */
+    public function serialize(PointInterface $point);
+
+    /**
+     * @param  CurveFpInterface $curve Curve that contains the serialized point
+     * @param  string $string
+     * @return PointInterface
+     */
+    public function unserialize(CurveFpInterface $curve, $string);
+}

--- a/libs/TLS/Mdanter/Ecc/Serializer/Point/UncompressedPointSerializer.php
+++ b/libs/TLS/Mdanter/Ecc/Serializer/Point/UncompressedPointSerializer.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Mdanter\Ecc\Serializer\Point;
+
+use Mdanter\Ecc\Math\GmpMathInterface;
+use Mdanter\Ecc\Primitives\PointInterface;
+use Mdanter\Ecc\Primitives\CurveFpInterface;
+use Mdanter\Ecc\Serializer\Util\CurveOidMapper;
+use Mdanter\Ecc\Util\BinaryString;
+
+class UncompressedPointSerializer implements PointSerializerInterface
+{
+    /**
+     * @var GmpMathInterface
+     */
+    private $adapter;
+
+    /**
+     * @param GmpMathInterface $adapter
+     */
+    public function __construct(GmpMathInterface $adapter)
+    {
+        $this->adapter = $adapter;
+    }
+
+    /**
+     * @param PointInterface $point
+     * @return string
+     */
+    public function serialize(PointInterface $point)
+    {
+        $length = CurveOidMapper::getByteSize($point->getCurve()) * 2;
+
+        $hexString = '04';
+        $hexString .= str_pad(gmp_strval($point->getX(), 16), $length, '0', STR_PAD_LEFT);
+        $hexString .= str_pad(gmp_strval($point->getY(), 16), $length, '0', STR_PAD_LEFT);
+
+        return $hexString;
+    }
+
+    /**
+     * @param CurveFpInterface $curve
+     * @param string $data
+     * @return PointInterface
+     */
+    public function unserialize(CurveFpInterface $curve, $data)
+    {
+        if (BinaryString::substring($data, 0, 2) != '04') {
+            throw new \InvalidArgumentException('Invalid data: only uncompressed keys are supported.');
+        }
+
+        $data = BinaryString::substring($data, 2);
+        $dataLength = BinaryString::length($data);
+
+        $x = gmp_init(BinaryString::substring($data, 0, $dataLength / 2), 16);
+        $y = gmp_init(BinaryString::substring($data, $dataLength / 2), 16);
+
+        return $curve->getPoint($x, $y);
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Serializer/PrivateKey/DerPrivateKeySerializer.php
+++ b/libs/TLS/Mdanter/Ecc/Serializer/PrivateKey/DerPrivateKeySerializer.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Mdanter\Ecc\Serializer\PrivateKey;
+
+use FG\ASN1\Object;
+use FG\ASN1\Universal\Sequence;
+use FG\ASN1\Universal\Integer;
+use FG\ASN1\Universal\BitString;
+use FG\ASN1\Universal\OctetString;
+use Mdanter\Ecc\Crypto\Key\PrivateKeyInterface;
+use Mdanter\Ecc\Math\GmpMathInterface;
+use Mdanter\Ecc\Math\MathAdapterFactory;
+use Mdanter\Ecc\Serializer\Util\CurveOidMapper;
+use Mdanter\Ecc\Serializer\PublicKey\PemPublicKeySerializer;
+use Mdanter\Ecc\Serializer\PublicKey\DerPublicKeySerializer;
+use FG\ASN1\ExplicitlyTaggedObject;
+
+/**
+ * PEM Private key formatter
+ *
+ * @link https://tools.ietf.org/html/rfc5915
+ */
+class DerPrivateKeySerializer implements PrivateKeySerializerInterface
+{
+    const VERSION = 1;
+
+    /**
+     * @var GmpMathInterface|null
+     */
+    private $adapter;
+
+    /**
+     * @var DerPublicKeySerializer
+     */
+    private $pubKeySerializer;
+
+    /**
+     * @param GmpMathInterface $adapter
+     * @param PemPublicKeySerializer $pubKeySerializer
+     */
+    public function __construct(GmpMathInterface $adapter = null, PemPublicKeySerializer $pubKeySerializer = null)
+    {
+        $this->adapter = $adapter ?: MathAdapterFactory::getAdapter();
+        $this->pubKeySerializer = $pubKeySerializer ?: new DerPublicKeySerializer($this->adapter);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\Serializer\PrivateKeySerializerInterface::serialize()
+     */
+    public function serialize(PrivateKeyInterface $key)
+    {
+        $privateKeyInfo = new Sequence(
+            new Integer(self::VERSION),
+            new OctetString($this->formatKey($key)),
+            new ExplicitlyTaggedObject(0, CurveOidMapper::getCurveOid($key->getPoint()->getCurve())),
+            new ExplicitlyTaggedObject(1, $this->encodePubKey($key))
+        );
+
+        return $privateKeyInfo->getBinary();
+    }
+
+    /**
+     * @param PrivateKeyInterface $key
+     * @return BitString
+     */
+    private function encodePubKey(PrivateKeyInterface $key)
+    {
+        return new BitString(
+            $this->pubKeySerializer->getUncompressedKey($key->getPublicKey())
+        );
+    }
+
+    /**
+     * @param PrivateKeyInterface $key
+     * @return string
+     */
+    private function formatKey(PrivateKeyInterface $key)
+    {
+        return gmp_strval($key->getSecret(), 16);
+    }
+
+    /**
+     * @param string $data
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\Serializer\PrivateKeySerializerInterface::parse()
+     * @throws \FG\ASN1\Exception\ParserException
+     */
+    public function parse($data)
+    {
+        $asnObject = Object::fromBinary($data);
+
+        if (!($asnObject instanceof Sequence) || $asnObject->getNumberofChildren() !== 4) {
+            throw new \RuntimeException('Invalid data.');
+        }
+
+        $children = $asnObject->getChildren();
+
+        $version = $children[0];
+
+        if ($version->getContent() != 1) {
+            throw new \RuntimeException('Invalid data: only version 1 (RFC5915) keys are supported.');
+        }
+
+        $key = gmp_init($children[1]->getContent(), 16);
+        $oid = $children[2]->getContent()[0];
+        $generator = CurveOidMapper::getGeneratorFromOid($oid);
+
+        return $generator->getPrivateKeyFrom($key);
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Serializer/PrivateKey/PemPrivateKeySerializer.php
+++ b/libs/TLS/Mdanter/Ecc/Serializer/PrivateKey/PemPrivateKeySerializer.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Mdanter\Ecc\Serializer\PrivateKey;
+
+use Mdanter\Ecc\Crypto\Key\PrivateKeyInterface;
+
+/**
+ * PEM Private key formatter
+ *
+ * @link https://tools.ietf.org/html/rfc5915
+ */
+class PemPrivateKeySerializer implements PrivateKeySerializerInterface
+{
+    /**
+     * @var DerPrivateKeySerializer
+     */
+    private $derSerializer;
+
+    /**
+     * @param DerPrivateKeySerializer $derSerializer
+     */
+    public function __construct(DerPrivateKeySerializer $derSerializer)
+    {
+        $this->derSerializer = $derSerializer;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\Serializer\PrivateKeySerializerInterface::serialize()
+     */
+    public function serialize(PrivateKeyInterface $key)
+    {
+        $privateKeyInfo = $this->derSerializer->serialize($key);
+
+        $content = '-----BEGIN EC PRIVATE KEY-----' . PHP_EOL;
+        $content .= trim(chunk_split(base64_encode($privateKeyInfo), 64, PHP_EOL)) . PHP_EOL;
+        $content .= '-----END EC PRIVATE KEY-----';
+
+        return $content;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\Serializer\PrivateKeySerializerInterface::parse()
+     */
+    public function parse($formattedKey)
+    {
+        $formattedKey = str_replace('-----BEGIN EC PRIVATE KEY-----', '', $formattedKey);
+        $formattedKey = str_replace('-----END EC PRIVATE KEY-----', '', $formattedKey);
+
+        $data = base64_decode($formattedKey);
+
+        return $this->derSerializer->parse($data);
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Serializer/PrivateKey/PrivateKeySerializerInterface.php
+++ b/libs/TLS/Mdanter/Ecc/Serializer/PrivateKey/PrivateKeySerializerInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Mdanter\Ecc\Serializer\PrivateKey;
+
+use Mdanter\Ecc\Crypto\Key\PrivateKeyInterface;
+
+interface PrivateKeySerializerInterface
+{
+    /**
+     *
+     * @param  PrivateKeyInterface $key
+     * @return string
+     */
+    public function serialize(PrivateKeyInterface $key);
+
+    /**
+     *
+     * @param  string $formattedKey
+     * @return PrivateKeyInterface
+     */
+    public function parse($formattedKey);
+}

--- a/libs/TLS/Mdanter/Ecc/Serializer/PublicKey/Der/Formatter.php
+++ b/libs/TLS/Mdanter/Ecc/Serializer/PublicKey/Der/Formatter.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Mdanter\Ecc\Serializer\PublicKey\Der;
+
+use FG\ASN1\Universal\Sequence;
+use FG\ASN1\Universal\ObjectIdentifier;
+use FG\ASN1\Universal\BitString;
+use Mdanter\Ecc\Math\GmpMathInterface;
+use Mdanter\Ecc\Primitives\PointInterface;
+use Mdanter\Ecc\Crypto\Key\PublicKeyInterface;
+use Mdanter\Ecc\Curves\NamedCurveFp;
+use Mdanter\Ecc\Serializer\Util\CurveOidMapper;
+use Mdanter\Ecc\Serializer\PublicKey\DerPublicKeySerializer;
+use Mdanter\Ecc\Serializer\Point\PointSerializerInterface;
+use Mdanter\Ecc\Serializer\Point\UncompressedPointSerializer;
+
+class Formatter
+{
+
+    /**
+     * @var GmpMathInterface
+     */
+    private $adapter;
+
+    /**
+     * @var UncompressedPointSerializer
+     */
+    private $pointSerializer;
+
+    /**
+     * Formatter constructor.
+     * @param GmpMathInterface $adapter
+     * @param PointSerializerInterface|null $pointSerializer
+     */
+    public function __construct(GmpMathInterface $adapter, PointSerializerInterface $pointSerializer = null)
+    {
+        $this->adapter = $adapter;
+        $this->pointSerializer = $pointSerializer ?: new UncompressedPointSerializer($adapter);
+    }
+
+    /**
+     * @param PublicKeyInterface $key
+     * @return string
+     */
+    public function format(PublicKeyInterface $key)
+    {
+        if (!($key->getCurve() instanceof NamedCurveFp)) {
+            throw new \RuntimeException('Not implemented for unnamed curves');
+        }
+
+        $sequence = new Sequence(
+            new Sequence(
+                new ObjectIdentifier(DerPublicKeySerializer::X509_ECDSA_OID),
+                CurveOidMapper::getCurveOid($key->getCurve())
+            ),
+            new BitString($this->encodePoint($key->getPoint()))
+        );
+
+        return $sequence->getBinary();
+    }
+
+    /**
+     * @param PointInterface $point
+     * @return string
+     */
+    public function encodePoint(PointInterface $point)
+    {
+        return $this->pointSerializer->serialize($point);
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Serializer/PublicKey/Der/Parser.php
+++ b/libs/TLS/Mdanter/Ecc/Serializer/PublicKey/Der/Parser.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Mdanter\Ecc\Serializer\PublicKey\Der;
+
+use FG\ASN1\Object;
+use FG\ASN1\Universal\Sequence;
+use Mdanter\Ecc\Math\GmpMathInterface;
+use Mdanter\Ecc\Serializer\Util\CurveOidMapper;
+use Mdanter\Ecc\Primitives\GeneratorPoint;
+use Mdanter\Ecc\Serializer\PublicKey\DerPublicKeySerializer;
+use Mdanter\Ecc\Serializer\Point\PointSerializerInterface;
+use Mdanter\Ecc\Serializer\Point\UncompressedPointSerializer;
+use Mdanter\Ecc\Crypto\Key\PublicKey;
+
+class Parser
+{
+
+    /**
+     * @var GmpMathInterface
+     */
+    private $adapter;
+
+    /**
+     * @var UncompressedPointSerializer
+     */
+    private $pointSerializer;
+
+    /**
+     * Parser constructor.
+     * @param GmpMathInterface $adapter
+     * @param PointSerializerInterface|null $pointSerializer
+     */
+    public function __construct(GmpMathInterface $adapter, PointSerializerInterface $pointSerializer = null)
+    {
+        $this->adapter = $adapter;
+        $this->pointSerializer = $pointSerializer ?: new UncompressedPointSerializer($adapter);
+    }
+
+    /**
+     * @param string $binaryData
+     * @return PublicKey
+     * @throws \FG\ASN1\Exception\ParserException
+     */
+    public function parse($binaryData)
+    {
+        $asnObject = Object::fromBinary($binaryData);
+
+        if (!($asnObject instanceof Sequence) || $asnObject->getNumberofChildren() != 2) {
+            throw new \RuntimeException('Invalid data.');
+        }
+
+        $children = $asnObject->getChildren();
+
+        $oid = $children[0]->getChildren()[0];
+        $curveOid = $children[0]->getChildren()[1];
+        $encodedKey = $children[1];
+
+        if ($oid->getContent() !== DerPublicKeySerializer::X509_ECDSA_OID) {
+            throw new \RuntimeException('Invalid data: non X509 data.');
+        }
+
+        $generator = CurveOidMapper::getGeneratorFromOid($curveOid);
+
+        return $this->parseKey($generator, $encodedKey->getContent());
+    }
+
+    /**
+     * @param GeneratorPoint $generator
+     * @param $data
+     * @return PublicKey
+     */
+    public function parseKey(GeneratorPoint $generator, $data)
+    {
+        $point = $this->pointSerializer->unserialize($generator->getCurve(), $data);
+
+        return new PublicKey($this->adapter, $generator, $point);
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Serializer/PublicKey/DerPublicKeySerializer.php
+++ b/libs/TLS/Mdanter/Ecc/Serializer/PublicKey/DerPublicKeySerializer.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Mdanter\Ecc\Serializer\PublicKey;
+
+use Mdanter\Ecc\Crypto\Key\PublicKeyInterface;
+use Mdanter\Ecc\Math\GmpMathInterface;
+use Mdanter\Ecc\Math\MathAdapterFactory;
+use Mdanter\Ecc\Serializer\PublicKey\Der\Formatter;
+use Mdanter\Ecc\Serializer\PublicKey\Der\Parser;
+
+/**
+ *
+ * @link https://tools.ietf.org/html/rfc5480#page-3
+ */
+class DerPublicKeySerializer implements PublicKeySerializerInterface
+{
+    const X509_ECDSA_OID = '1.2.840.10045.2.1';
+
+    /**
+     *
+     * @var GmpMathInterface
+     */
+    private $adapter;
+
+    /**
+     *
+     * @var Formatter
+     */
+    private $formatter;
+
+    /**
+     *
+     * @var Parser
+     */
+    private $parser;
+
+    /**
+     *
+     * @param GmpMathInterface $adapter
+     */
+    public function __construct(GmpMathInterface $adapter = null)
+    {
+        $this->adapter = $adapter ?: MathAdapterFactory::getAdapter();
+
+        $this->formatter = new Formatter($this->adapter);
+        $this->parser = new Parser($this->adapter);
+    }
+
+    /**
+     *
+     * @param  PublicKeyInterface $key
+     * @return string
+     */
+    public function serialize(PublicKeyInterface $key)
+    {
+        return $this->formatter->format($key);
+    }
+
+    public function getUncompressedKey(PublicKeyInterface $key)
+    {
+        return $this->formatter->encodePoint($key->getPoint());
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\Serializer\PublicKey\PublicKeySerializerInterface::parse()
+     */
+    public function parse($string)
+    {
+        return $this->parser->parse($string);
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Serializer/PublicKey/PemPublicKeySerializer.php
+++ b/libs/TLS/Mdanter/Ecc/Serializer/PublicKey/PemPublicKeySerializer.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Mdanter\Ecc\Serializer\PublicKey;
+
+use Mdanter\Ecc\Crypto\Key\PublicKeyInterface;
+
+/**
+ *
+ * @link https://tools.ietf.org/html/rfc5480#page-3
+ */
+class PemPublicKeySerializer implements PublicKeySerializerInterface
+{
+
+    /**
+     * @var DerPublicKeySerializer
+     */
+    private $derSerializer;
+
+    /**
+     * @param DerPublicKeySerializer $serializer
+     */
+    public function __construct(DerPublicKeySerializer $serializer)
+    {
+        $this->derSerializer = $serializer;
+    }
+
+    /**
+     *
+     * @param  PublicKeyInterface $key
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\Serializer\PublicKey\PublicKeySerializerInterface::serialize()
+     */
+    public function serialize(PublicKeyInterface $key)
+    {
+        $publicKeyInfo = $this->derSerializer->serialize($key);
+
+        $content = '-----BEGIN PUBLIC KEY-----' . PHP_EOL;
+        $content .= trim(chunk_split(base64_encode($publicKeyInfo), 64, PHP_EOL)) . PHP_EOL;
+        $content .= '-----END PUBLIC KEY-----';
+
+        return $content;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Mdanter\Ecc\Serializer\PublicKey\PublicKeySerializerInterface::parse()
+     */
+    public function parse($formattedKey)
+    {
+        $formattedKey = str_replace('-----BEGIN PUBLIC KEY-----', '', $formattedKey);
+        $formattedKey = str_replace('-----END PUBLIC KEY-----', '', $formattedKey);
+
+        $data = base64_decode($formattedKey);
+
+        return $this->derSerializer->parse($data);
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Serializer/PublicKey/PublicKeySerializerInterface.php
+++ b/libs/TLS/Mdanter/Ecc/Serializer/PublicKey/PublicKeySerializerInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Mdanter\Ecc\Serializer\PublicKey;
+
+use Mdanter\Ecc\Crypto\Key\PublicKeyInterface;
+
+interface PublicKeySerializerInterface
+{
+    /**
+     *
+     * @param  PublicKeyInterface $key
+     * @return string
+     */
+    public function serialize(PublicKeyInterface $key);
+
+    /**
+     *
+     * @param  string $formattedKey
+     * @return PublicKeyInterface
+     */
+    public function parse($formattedKey);
+}

--- a/libs/TLS/Mdanter/Ecc/Serializer/Signature/Der/Formatter.php
+++ b/libs/TLS/Mdanter/Ecc/Serializer/Signature/Der/Formatter.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Mdanter\Ecc\Serializer\Signature\Der;
+
+use FG\ASN1\Universal\Integer;
+use FG\ASN1\Universal\Sequence;
+use Mdanter\Ecc\Crypto\Signature\SignatureInterface;
+
+class Formatter
+{
+    /**
+     * @param SignatureInterface $signature
+     * @return Sequence
+     */
+    public function toAsn(SignatureInterface $signature)
+    {
+        return new Sequence(
+            new Integer(gmp_strval($signature->getR(), 10)),
+            new Integer(gmp_strval($signature->getS(), 10))
+        );
+    }
+
+    /**
+     * @param SignatureInterface $signature
+     * @return string
+     */
+    public function serialize(SignatureInterface $signature)
+    {
+        return $this->toAsn($signature)->getBinary();
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Serializer/Signature/Der/Parser.php
+++ b/libs/TLS/Mdanter/Ecc/Serializer/Signature/Der/Parser.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Mdanter\Ecc\Serializer\Signature\Der;
+
+use FG\ASN1\Identifier;
+use FG\ASN1\Object;
+use Mdanter\Ecc\Crypto\Signature\Signature;
+
+class Parser
+{
+    /**
+     * @param string $binary
+     * @return Signature
+     * @throws \FG\ASN1\Exception\ParserException
+     */
+    public function parse($binary)
+    {
+        $object = Object::fromBinary($binary);
+        if ($object->getType() !== Identifier::SEQUENCE) {
+            throw new \RuntimeException('Invalid data');
+        }
+
+        $content = $object->getContent();
+        if (count($content) !== 2) {
+            throw new \RuntimeException('Failed to parse signature');
+        }
+
+        /** @var \FG\ASN1\Universal\Integer $r */
+        /** @var \FG\ASN1\Universal\Integer $s */
+        list($r, $s) = $content;
+        if ($r->getType() !== Identifier::INTEGER || $s->getType() !== Identifier::INTEGER) {
+            throw new \RuntimeException('Failed to parse signature');
+        }
+
+        return new Signature(
+            gmp_init($r->getContent(), 10),
+            gmp_init($s->getContent(), 10)
+        );
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Serializer/Signature/DerSignatureSerializer.php
+++ b/libs/TLS/Mdanter/Ecc/Serializer/Signature/DerSignatureSerializer.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Mdanter\Ecc\Serializer\Signature;
+
+use Mdanter\Ecc\Crypto\Signature\Signature;
+use Mdanter\Ecc\Crypto\Signature\SignatureInterface;
+
+class DerSignatureSerializer
+{
+    /**
+     * @var Der\Parser
+     */
+    private $parser;
+
+    /**
+     * @var Der\Formatter
+     */
+    private $formatter;
+
+    /**
+     *
+     */
+    public function __construct()
+    {
+        $this->parser = new Der\Parser();
+        $this->formatter = new Der\Formatter();
+    }
+
+    /**
+     * @param SignatureInterface $signature
+     * @return string
+     */
+    public function serialize(SignatureInterface $signature)
+    {
+        return $this->formatter->serialize($signature);
+    }
+
+    /**
+     * @param string $binary
+     * @return Signature
+     * @throws \FG\ASN1\Exception\ParserException
+     */
+    public function parse($binary)
+    {
+        return $this->parser->parse($binary);
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Serializer/Util/CurveOidMapper.php
+++ b/libs/TLS/Mdanter/Ecc/Serializer/Util/CurveOidMapper.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Mdanter\Ecc\Serializer\Util;
+
+use FG\ASN1\Universal\ObjectIdentifier;
+use Mdanter\Ecc\Curves\NamedCurveFp;
+use Mdanter\Ecc\Curves\CurveFactory;
+use Mdanter\Ecc\Curves\NistCurve;
+use Mdanter\Ecc\Curves\SecgCurve;
+use Mdanter\Ecc\Primitives\CurveFpInterface;
+
+class CurveOidMapper
+{
+    const NIST_P192_OID = '1.2.840.10045.3.1.1';
+
+    const NIST_P224_OID = '1.3.132.0.33';
+
+    const NIST_P256_OID = '1.2.840.10045.3.1.7';
+
+    const NIST_P384_OID = '1.3.132.0.34';
+
+    const NIST_P521_OID = '1.3.132.0.35';
+
+    const SECP_112R1_OID = '1.3.132.0.6';
+
+    const SECP_256K1_OID = '1.3.132.0.10';
+
+    const SECP_256R1_OID = '1.2.840.10045.3.1.7';
+
+    const SECP_384R1_OID = '1.3.132.0.34';
+
+    /**
+     * @var array
+     */
+    private static $oidMap = [
+        NistCurve::NAME_P192 => self::NIST_P192_OID,
+        NistCurve::NAME_P224 => self::NIST_P224_OID,
+        NistCurve::NAME_P256 => self::NIST_P256_OID,
+        NistCurve::NAME_P384 => self::NIST_P384_OID,
+        NistCurve::NAME_P521 => self::NIST_P521_OID,
+        SecgCurve::NAME_SECP_112R1 => self::SECP_112R1_OID,
+        SecgCurve::NAME_SECP_256K1 => self::SECP_256K1_OID,
+        SecgCurve::NAME_SECP_256R1 => self::SECP_256R1_OID,
+        SecgCurve::NAME_SECP_384R1 => self::SECP_384R1_OID,
+    ];
+
+    /**
+     * @var array
+     */
+    private static $sizeMap = [
+        NistCurve::NAME_P192 => 24,
+        NistCurve::NAME_P224 => 28,
+        NistCurve::NAME_P256 => 32,
+        NistCurve::NAME_P384 => 48,
+        NistCurve::NAME_P521 => 66,
+        SecgCurve::NAME_SECP_112R1 => 14,
+        SecgCurve::NAME_SECP_256K1 => 32,
+        SecgCurve::NAME_SECP_256R1 => 32,
+        SecgCurve::NAME_SECP_384R1 => 48,
+    ];
+
+    /**
+     * @return array
+     */
+    public static function getNames()
+    {
+        return array_keys(self::$oidMap);
+    }
+
+    /**
+     * @param CurveFpInterface $curve
+     * @return mixed
+     */
+    public static function getByteSize(CurveFpInterface $curve)
+    {
+        if ($curve instanceof NamedCurveFp && array_key_exists($curve->getName(), self::$sizeMap)) {
+            return self::$sizeMap[$curve->getName()];
+        }
+
+        throw new \RuntimeException('Unsupported curve type.');
+    }
+
+    /**
+     * @param NamedCurveFp $curve
+     * @return ObjectIdentifier
+     */
+    public static function getCurveOid(NamedCurveFp $curve)
+    {
+        if (array_key_exists($curve->getName(), self::$oidMap)) {
+            $oidString = self::$oidMap[$curve->getName()];
+
+            return new ObjectIdentifier($oidString);
+        }
+
+        throw new \RuntimeException('Unsupported curve type.');
+    }
+
+    /**
+     * @param ObjectIdentifier $oid
+     * @return \Mdanter\Ecc\Primitives\GeneratorPoint
+     */
+    public static function getCurveFromOid(ObjectIdentifier $oid)
+    {
+        $oidString = $oid->getContent();
+        $invertedMap = array_flip(self::$oidMap);
+
+        if (array_key_exists($oidString, $invertedMap)) {
+            return CurveFactory::getCurveByName($invertedMap[$oidString]);
+        }
+
+        throw new \RuntimeException('Invalid data: unsupported curve.');
+    }
+
+    /**
+     * @param ObjectIdentifier $oid
+     * @return \Mdanter\Ecc\Primitives\GeneratorPoint
+     */
+    public static function getGeneratorFromOid(ObjectIdentifier $oid)
+    {
+        $oidString = $oid->getContent();
+        $invertedMap = array_flip(self::$oidMap);
+
+        if (array_key_exists($oidString, $invertedMap)) {
+            return CurveFactory::getGeneratorByName($invertedMap[$oidString]);
+        }
+
+        throw new \RuntimeException('Invalid data: unsupported generator.');
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Util/BinaryString.php
+++ b/libs/TLS/Mdanter/Ecc/Util/BinaryString.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Mdanter\Ecc\Util;
+
+class BinaryString
+{
+    /**
+     * Multi-byte-safe string length calculation
+     *
+     * @param string $str
+     * @return int
+     */
+    public static function length($str)
+    {
+        // Premature optimization: cache the function_exists() result
+        static $exists = null;
+        if ($exists === null) {
+            $exists = function_exists('mb_strlen');
+        }
+
+        // If it exists, we need to make sure we're using 8bit mode
+        if ($exists) {
+            return mb_strlen($str, '8bit');
+        }
+        return strlen($str);
+    }
+
+    /**
+     * Multi-byte-safe substring calculation
+     *
+     * @param string $str
+     * @param int $start
+     * @param int $length (optional)
+     * @return string
+     */
+    public static function substring($str, $start = 0, $length = null)
+    {
+        // Premature optimization: cache the function_exists() result
+        static $exists = null;
+        if ($exists === null) {
+            $exists = function_exists('mb_substr');
+        }
+
+        // If it exists, we need to make sure we're using 8bit mode
+        if ($exists) {
+            return mb_substr($str, $start, $length, '8bit');
+        } elseif ($length !== null) {
+            return substr($str, $start, $length);
+        }
+        return substr($str, $start);
+    }
+
+    /**
+     * Equivalent to hash_equals() in PHP 5.6
+     *
+     * @param string $knownString
+     * @param string $userString
+     *
+     * @return bool
+     */
+    public static function constantTimeCompare($knownString, $userString)
+    {
+        return hash_equals($knownString, $userString);
+    }
+}

--- a/libs/TLS/Mdanter/Ecc/Util/NumberSize.php
+++ b/libs/TLS/Mdanter/Ecc/Util/NumberSize.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Mdanter\Ecc\Util;
+
+use Mdanter\Ecc\Math\GmpMathInterface;
+
+class NumberSize
+{
+
+    /**
+     * @param GmpMathInterface $adapter
+     * @param \GMP $x
+     * @return float
+     */
+    public static function getCeiledByteSize(GmpMathInterface $adapter, \GMP $x)
+    {
+        $log2 = 0;
+        while ($x = $adapter->rightShift($x, 1)) {
+            $log2++;
+        }
+
+        return ceil($log2 / 8);
+    }
+
+    /**
+     * @param GmpMathInterface $adapter
+     * @param \GMP $x
+     * @return float
+     */
+    public static function getFlooredByteSize(GmpMathInterface $adapter, \GMP $x)
+    {
+        $log2 = 0;
+        while ($x = $adapter->rightShift($x, 1)) {
+            $log2++;
+        }
+
+        return floor($log2 / 8) + 1;
+    }
+
+    /**
+     * Returns the number of mininum required bytes to store a given number. Non-significant upper bits are not counted.
+     *
+     * @param  GmpMathInterface $adapter
+     * @param  \GMP $x
+     * @return integer
+     *
+     * @link https://www.openssl.org/docs/crypto/BN_num_bytes.html
+     */
+    public static function bnNumBytes(GmpMathInterface $adapter, \GMP $x)
+    {
+        // https://github.com/luvit/openssl/blob/master/openssl/crypto/bn/bn.h#L402
+        return floor((self::bnNumBits($adapter, $x) + 7) / 8);
+    }
+
+    /**
+     * Returns the number of bits used to store this number. Non-singicant upper bits are not counted.
+     *
+     * @param  GmpMathInterface $adapter
+     * @param  \GMP $x
+     * @return number
+     *
+     * @link https://www.openssl.org/docs/crypto/BN_num_bytes.html
+     */
+    public static function bnNumBits(GmpMathInterface $adapter, \GMP $x)
+    {
+        $zero = gmp_init(0, 10);
+        if ($adapter->equals($x, $zero)) {
+            return 0;
+        }
+
+        $log2 = 0;
+        while (false === $adapter->equals($x, $zero)) {
+            $x = $adapter->rightShift($x, 1);
+            $log2++;
+        }
+
+        return $log2;
+    }
+}

--- a/libs/TLS/PTLS/AEADGcm.php
+++ b/libs/TLS/PTLS/AEADGcm.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace PTLS;
+
+use AESGCM\AESGCM;
+use PTLS\Exceptions\TLSAlertException;
+use PTLS\Content\Alert;
+
+class AEADGcm
+{
+    // A tag is alway 16 bytes long
+    const TAG_LEN = 16;
+
+    /**
+     * PHP supports AES GCM from version 7.1
+     *
+     * https://github.com/php/php-src/pull/1716
+     * https://wiki.php.net/rfc/openssl_aead
+     *
+     */
+    private static function useOpenSSL()
+    {
+        return (version_compare(PHP_VERSION, '7.1') >= 0) ? true : false;
+    }
+
+    /**
+     * https://github.com/bukka/php-crypto
+     *
+     * Objective PHP binding of OpenSSL Crypto library
+     *
+     */
+    private static function useSO()
+    {
+        return class_exists('\Crypto\Cipher') ? true : false;
+    }
+
+    private static function bitLen($password)
+    {
+        // 128(16), 192(24) or 256(32)
+        $l = strlen($password);
+
+        if ($l != 16 && $l != 24 && $l != 32) {
+            throw new TLSAlertException(Alert::create(Alert::INTERNAL_ERROR), "Invalid gcm key length: $l");
+        }
+
+        return $l * 8;
+    }
+
+    private static function getMethod($password)
+    {
+        return "aes-" . self::bitLen($password) . "-gcm";
+    }
+
+    public static function encrypt($data, $password, $IV, $AAD)
+    {
+        if (self::useOpenSSL()) {
+            $method = self::getMethod($password);
+            $encrypt = openssl_encrypt($data, $method, $password, OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING, $IV, $tag, $AAD);
+        } elseif (self::useSO()) {
+            try {
+                $cipher = \Crypto\Cipher::aes(\Crypto\Cipher::MODE_GCM, self::bitLen($password));
+                $cipher->setAAD($AAD);
+                $encrypt = $cipher->encrypt($data, $password, $IV);
+                $tag = $cipher->getTag();
+            } catch (\Exception $e) {
+                //echo $e->getMessage();
+                return false;
+            }
+        } else {
+            try {
+                list($encrypt, $tag) = AESGCM::encrypt($password, $IV, $data, $AAD);
+            } catch (\Exception $e) {
+                //echo $e->getMessage();
+                return false;
+            }
+        }
+
+        return $encrypt . $tag;
+    }
+
+    public static function decrypt($encData, $password, $IV, $AAD)
+    {
+        /*
+         * https://tools.ietf.org/html/rfc5116#section-5.1
+         *
+         * An authentication tag with a length of 16 octets (128
+         * bits) is used.  The AEAD_AES_128_GCM ciphertext is formed by
+         * appending the authentication tag provided as an output to the GCM
+         * encryption operation to the ciphertext that is output by that
+         * operation.
+         *
+         * ciphertext is exactly 16 octets longer than its
+         * corresponding plaintext.
+         */
+        if (strlen($encData) < self::TAG_LEN) {
+            return false;
+        }
+
+        // Get the tag appended to cipher text
+        $tag = substr($encData, strlen($encData) - self::TAG_LEN, self::TAG_LEN);
+
+        // Resize the cipher text
+        $encData = substr($encData, 0, strlen($encData) - self::TAG_LEN);
+
+        if (self::useOpenSSL()) {
+            $method = self::getMethod($password);
+            $data = openssl_decrypt($encData, $method, $password, OPENSSL_RAW_DATA, $IV, $tag, $AAD);
+        } elseif (self::useSO()) {
+            try {
+                $cipher = \Crypto\Cipher::aes(\Crypto\Cipher::MODE_GCM, self::bitLen($password));
+                $cipher->setTag($tag);
+                $cipher->setAAD($AAD);
+                $data = $cipher->decrypt($encData, $password, $IV);
+            } catch (\Exception $e) {
+                return false;
+            }
+        } else {
+            try {
+                $data = AESGCM::decrypt($password, $IV, $encData, $AAD, $tag);
+            } catch (\Exception $e) {
+                //echo $e->getMessage();
+                return false;
+            }
+        }
+
+        return $data;
+    }
+}

--- a/libs/TLS/PTLS/Buffer.php
+++ b/libs/TLS/PTLS/Buffer.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace PTLS;
+
+/**
+ * Simple buffering
+ */
+class Buffer
+{
+    private $buffer;
+
+    public function set($data)
+    {
+        $this->buffer = $data;
+        return $this;
+    }
+
+    public function append($data)
+    {
+        $this->buffer .= $data;
+        return $this;
+    }
+
+    public function flush()
+    {
+        $data = $this->buffer;
+        $this->buffer = null;
+        return $data;
+    }
+
+    public function get()
+    {
+        return $this->buffer;
+    }
+
+    public function length()
+    {
+        return strlen($this->buffer);
+    }
+}

--- a/libs/TLS/PTLS/CipherSuites.php
+++ b/libs/TLS/PTLS/CipherSuites.php
@@ -1,0 +1,262 @@
+<?php
+
+namespace PTLS;
+
+use PTLS\TLS;
+use PTLS\Exceptions\TLSAlertException;
+use PTLS\Content\Alert;
+
+class CipherSuites
+{
+    const TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 = 0xC02F;
+    const TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 = 0xC030;
+    const TLS_RSA_WITH_AES_128_GCM_SHA256 = 0x009C;
+    const TLS_RSA_WITH_AES_256_GCM_SHA384 = 0x009D;
+    const TLS_RSA_WITH_AES_128_CBC_SHA = 0x002F;
+    const TLS_RSA_WITH_AES_256_CBC_SHA = 0x0035;
+    const TLS_RSA_WITH_AES_128_CBC_SHA256 = 0x003C;
+    const TLS_RSA_WITH_AES_256_CBC_SHA256 = 0x003D;
+    const TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA = 0xC013;
+    const TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA = 0xC014;
+
+    private static $cipherList = [
+        self::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 =>
+            ['cipher_type' => self::CIPHER_TYPE_AEAD, 'crypto_method' => 'AES-128-GCM', 'mac_len' => 0, 'iv_len' => 4, 'key_len' => 16, 'mac' => 'sha256'],
+
+        self::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 =>
+            ['cipher_type' => self::CIPHER_TYPE_AEAD, 'crypto_method' => 'AES-256-GCM', 'mac_len' => 0, 'iv_len' => 4, 'key_len' => 32, 'mac' => 'sha384'],
+
+        self::TLS_RSA_WITH_AES_128_GCM_SHA256 =>
+            ['cipher_type' => self::CIPHER_TYPE_AEAD, 'crypto_method' => 'AES-128-GCM', 'mac_len' => 0, 'iv_len' => 4, 'key_len' => 16, 'mac' => 'sha256'],
+
+        self::TLS_RSA_WITH_AES_256_GCM_SHA384 =>
+            ['cipher_type' => self::CIPHER_TYPE_AEAD, 'crypto_method' => 'AES-256-GCM', 'mac_len' => 0, 'iv_len' => 4, 'key_len' => 32, 'mac' => 'sha384'],
+
+        self::TLS_RSA_WITH_AES_256_CBC_SHA =>
+            ['cipher_type' => self::CIPHER_TYPE_BLOCK, 'crypto_method' => 'AES-256-CBC', 'mac_len' => 20, 'iv_len' => 16, 'key_len' => 32, 'mac' => 'sha1'],
+
+        self::TLS_RSA_WITH_AES_128_CBC_SHA =>
+            ['cipher_type' => self::CIPHER_TYPE_BLOCK, 'crypto_method' => 'AES-128-CBC', 'mac_len' => 20, 'iv_len' => 16, 'key_len' => 16, 'mac' => 'sha1'],
+
+        self::TLS_RSA_WITH_AES_128_CBC_SHA256 =>
+            ['cipher_type' => self::CIPHER_TYPE_BLOCK, 'crypto_method' => 'AES-128-CBC', 'mac_len' => 32, 'iv_len' => 16, 'key_len' => 16, 'mac' => 'sha256'],
+
+        self::TLS_RSA_WITH_AES_256_CBC_SHA256 =>
+            ['cipher_type' => self::CIPHER_TYPE_BLOCK, 'crypto_method' => 'AES-256-CBC', 'mac_len' => 32, 'iv_len' => 16, 'key_len' => 32, 'mac' => 'sha256'],
+
+        self::TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA =>
+            ['cipher_type' => self::CIPHER_TYPE_BLOCK, 'crypto_method' => 'AES-128-CBC', 'mac_len' => 20, 'iv_len' => 16, 'key_len' => 16, 'mac' => 'sha1'],
+
+        self::TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA =>
+            ['cipher_type' => self::CIPHER_TYPE_BLOCK, 'crypto_method' => 'AES-256-CBC', 'mac_len' => 20, 'iv_len' => 16, 'key_len' => 32, 'mac' => 'sha1'],
+    ];
+
+    public static $enabledCipherSuites = [
+        self::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+        self::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+        self::TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+        self::TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+        self::TLS_RSA_WITH_AES_256_GCM_SHA384,
+        self::TLS_RSA_WITH_AES_128_GCM_SHA256,
+        self::TLS_RSA_WITH_AES_256_CBC_SHA256,
+        self::TLS_RSA_WITH_AES_256_CBC_SHA,
+        self::TLS_RSA_WITH_AES_128_CBC_SHA256,
+        self::TLS_RSA_WITH_AES_128_CBC_SHA,
+    ];
+
+    const CIPHER_TYPE_STREAM = 1;
+    const CIPHER_TYPE_BLOCK = 2;
+    const CIPHER_TYPE_AEAD = 3;
+
+    private $macLen;
+    private $ivLen;
+    private $keyLen;
+    private $macAlgorithm;
+    private $cryptoMethod;
+    private $cipherType;
+    private $cipherID;
+
+    public function __construct(array $arr)
+    {
+        $cipherID = $arr[0] << 8 | $arr[1];
+
+        if (!array_key_exists($cipherID, self::$cipherList)) {
+            throw new TLSAlertException(Alert::create(Alert::INTERNAL_ERROR), "Failed to initiate CipherSuite. cipherID: $cipherID");
+        }
+
+        $cipherSuite = self::$cipherList[$cipherID];
+
+        $this->cipherID = $cipherID;
+
+        $this->cipherType = $cipherSuite['cipher_type'];
+        $this->ivLen = $cipherSuite['iv_len'];
+        $this->keyLen = $cipherSuite['key_len'];
+        $this->macLen = $cipherSuite['mac_len'];
+        $this->cryptoMethod = $cipherSuite['crypto_method'];
+        $this->macAlgorithm = $cipherSuite['mac'];
+    }
+
+    public function isECDHEEnabled()
+    {
+        return self::isECDHE($this->cipherID);
+    }
+
+    public static function isGCM($cipherID)
+    {
+        switch ($cipherID) {
+            case self::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:
+            case self::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:
+            case self::TLS_RSA_WITH_AES_128_GCM_SHA256:
+            case self::TLS_RSA_WITH_AES_256_GCM_SHA384:
+                return true;
+        }
+
+        return false;
+    }
+
+    public static function isECDHE($cipherID)
+    {
+        switch ($cipherID) {
+            case self::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:
+            case self::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:
+            case self::TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA:
+            case self::TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA:
+                return true;
+        }
+
+        return false;
+    }
+
+    public static function pickCipherID(Core $core, array $arr)
+    {
+        $extensions = $core->extensions;
+
+        foreach ($arr as $val) {
+            list($cipher1, $cipher2) = $val;
+
+            $cipherID = $cipher1 << 8 | $cipher2;
+
+            if (in_array($cipherID, self::$enabledCipherSuites)) {
+                if (self::isECDHE($cipherID) && true !== $extensions->call('Curve', 'isEnabled', false)) {
+                    continue;
+                } else {
+                    return [$cipher1, $cipher2];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public static function decodeCipherList()
+    {
+        $data = '';
+
+        foreach (self::$enabledCipherSuites as $val) {
+            $data .= Core::_pack('C', $val >> 8) . Core::_pack('C', $val & 0x00ff);
+        }
+
+        return $data;
+    }
+
+    private function getProperty($property)
+    {
+        if (!property_exists($this, $property)) {
+            return;
+        }
+
+        return $this->$property;
+    }
+
+    public function getID()
+    {
+        $cipherID = $this->getProperty('cipherID');
+        return [$cipherID >> 8, $cipherID & 0x00ff];
+    }
+
+    /**
+     *
+     * https://tools.ietf.org/html/rfc5288 Page 2
+     *
+     * The Pseudo Random Function (PRF) algorithms SHALL be as follows:
+     *
+     *  For cipher suites ending with _SHA256, the PRF is the TLS PRF
+     * [RFC5246] with SHA-256 as the hash function.
+     *
+     *  For cipher suites ending with _SHA384, the PRF is the TLS PRF
+     * [RFC5246] with SHA-384 as the hash function.
+     *
+     * This is also used by Finished message in Handshake
+     */
+    public function getHashAlogV33()
+    {
+        if (self::isGCM($this->cipherID)) {
+            return $this->macAlgorithm;
+        }
+
+        return 'sha256';
+    }
+
+    public function getKeyLen()
+    {
+        return $this->getProperty('keyLen');
+    }
+
+    public function getIVLen()
+    {
+        return $this->getProperty('ivLen');
+    }
+
+    public function getMACLen()
+    {
+        return $this->getProperty('macLen');
+    }
+
+    public function getCipherType()
+    {
+        return $this->getProperty('cipherType');
+    }
+
+    public function blockDecrypt($encPayload, $sharedKey, $IV)
+    {
+        $data = openssl_decrypt($encPayload, $this->cryptoMethod, $sharedKey, OPENSSL_ZERO_PADDING | OPENSSL_RAW_DATA, $IV);
+        return $data;
+    }
+
+    public function blockEncrypt($payload, $sharedKey, $IV)
+    {
+        $encData = openssl_encrypt($payload, $this->cryptoMethod, $sharedKey, OPENSSL_RAW_DATA, $IV);
+        return $encData;
+    }
+
+    public function hashHmac($data, $secretMac, $binary = true)
+    {
+        return hash_hmac($this->macAlgorithm, $data, $secretMac, $binary);
+    }
+
+    public function gcmEncrypt($payload, $sharedKey, $nonce, $aad)
+    {
+        return AEADGcm::encrypt($payload, $sharedKey, $nonce, $aad);
+    }
+
+    public function gcmDecrypt($encData, $sharedKey, $nonce, $aad)
+    {
+        return AEADGcm::decrypt($encData, $sharedKey, $nonce, $aad);
+    }
+
+    public function debugInfo()
+    {
+        $class = new \ReflectionClass(__CLASS__);
+        $constants = array_flip($class->getConstants());
+
+        $outputs[] = 'Cipher ID:     ' . $constants[$this->cipherID];
+        $outputs[] = 'MAC Length:    ' . $this->macLen;
+        $outputs[] = 'IV Length:     ' . $this->ivLen;
+        $outputs[] = 'MAC Algorithm: ' . $this->macAlgorithm;
+
+        $r = "[CipherSuite]\n"
+            . implode("\n", $outputs);
+
+        return $r;
+    }
+}

--- a/libs/TLS/PTLS/Config.php
+++ b/libs/TLS/PTLS/Config.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace PTLS;
+
+use PTLS\Exceptions\TLSException;
+
+class Config
+{
+    const SERVER = true;
+    const CLIENT = false;
+
+    private $config;
+    private $isServer;
+
+    public function __construct($isServer, array $arrConfig)
+    {
+        $this->isServer = $isServer;
+        $this->config = [];
+
+        if ($isServer) {
+            $this->encodeServerConfig($arrConfig);
+        } else {
+            $this->encodeClientConfig($arrConfig);
+        }
+    }
+
+    private function encodeClientConfig(array $arrConfig)
+    {
+        // Setting up TLS version
+        if (isset($arrConfig['version'])) {
+            $this->config['version'] = $arrConfig['version'];
+        }
+    }
+
+    private function encodeServerConfig(array $arrConfig)
+    {
+        if (!isset($arrConfig['key_pair_files'])) {
+            throw new TLSException("No keyPairFiles");
+        }
+
+        $keyPairFiles = $arrConfig['key_pair_files'];
+
+        if (!isset($keyPairFiles['cert']) || !isset($keyPairFiles['key'])) {
+            throw new TLSException("Invalid keyPair");
+        }
+
+        $pemCrtFiles = $keyPairFiles['cert'];
+        $pemPriFile = $keyPairFiles['key'][0];
+        $pemPriPassCode = $keyPairFiles['key'][1];
+
+        $this->config['crt_ders'] = X509::crtFilePemToDer($pemCrtFiles);
+        $this->config['private_key'] = $keyPairFiles['key'];
+    }
+
+    public function get($key, $default = null)
+    {
+        return (isset($this->config[$key]) ? $this->config[$key] : $default);
+    }
+
+    public function isServer()
+    {
+        return $this->isServer;
+    }
+}

--- a/libs/TLS/PTLS/ConnectionDuplex.php
+++ b/libs/TLS/PTLS/ConnectionDuplex.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace PTLS;
+
+use PTLS\Record\BlockCipherRecord;
+use PTLS\Record\AEADCipherRecord;
+use PTLS\Record\Record;
+use PTLS\Exceptions\TLSException;
+use PTLS\Exceptions\TLSAlertException;
+use PTLS\Content\Alert;
+
+class ConnectionDuplex
+{
+    public $random;
+    public $MAC;
+    public $IV;
+    public $Key;
+    public $isCipherChanged;
+
+    private $core;
+    private $record;
+    private $cipherRecord;
+
+    public function __construct(Core $core)
+    {
+        $this->core = $core;
+        $this->record = new Record($this);
+        $this->isCipherChanged = false;
+    }
+
+    public function getCore()
+    {
+        return $this->core;
+    }
+
+    /**
+     * Switch over to cipher record
+     */
+    public function cipherChanged()
+    {
+        $core = $this->core;
+
+        if ($core->cipherSuite->getCipherType() == CipherSuites::CIPHER_TYPE_AEAD) {
+            $this->cipherRecord = new AEADCipherRecord($this);
+        } else {
+            $this->cipherRecord = new BlockCipherRecord($this);
+        }
+
+        $this->isCipherChanged = true;
+        return $this->cipherRecord;
+    }
+
+    /**
+     * Set secret keys needed for encryption
+     */
+    public function setSecretKeys(array $secretKeys)
+    {
+        $this->MAC = $secretKeys['MAC'];
+        $this->IV = $secretKeys['IV'];
+        $this->Key = $secretKeys['Key'];
+    }
+
+    public function getRecord()
+    {
+        if ($this->isCipherChanged) {
+            $record = $this->cipherRecord;
+        } else {
+            $record = $this->record;
+        }
+
+        return $record;
+    }
+
+    public function getContentType()
+    {
+        $record = $this->getRecord();
+        return $record->contentType;
+    }
+
+    public function encodeRecord($data)
+    {
+        while (!is_null($data) && strlen($data) > 0) {
+            $strlen = strlen($data);
+
+            $record = $this->getRecord();
+            $record->encode($data);
+            $data = $record->get('dataRest');
+
+            if ($strlen == strlen($data)) {
+                throw new TLSAlertException(Alert::create(Alert::INTERNAL_ERROR), "Failed on encodeRecord");
+            }
+        }
+    }
+
+    public function decodeRecord($data)
+    {
+        $core = $this->core;
+
+        if (!$core->isHandshaked) {
+            throw new TLSException("Handshake is not finished");
+        }
+
+        if (0 >= strlen($data)) {
+            throw new TLSException("Empty output");
+        }
+
+        $record = $this->getRecord();
+
+        $record->set('contentType', ContentType::APPLICATION_DATA)
+            ->set('payload', $data);
+
+        return $record->decode();
+    }
+}

--- a/libs/TLS/PTLS/Content/Alert.php
+++ b/libs/TLS/PTLS/Content/Alert.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace PTLS\Content;
+
+use PTLS\Core;
+use PTLS\ProtocolAbstract;
+
+/**
+ * https://tools.ietf.org/html/rfc5246#section-7.2
+ */
+class Alert extends ProtocolAbstract
+{
+    const CLOSE_NOTIFY = 0;
+    const UNEXPECTED_MESSAGE = 10;
+    const BAD_RECORD_MAC = 20;
+    const DECRYPTION_FAILED_RESERVED = 21;
+    const RECORD_OVERFLOW = 22;
+    const DECOMPRESSION_FAILURE = 30;
+    const HANDSHAKE_FAILURE = 40;
+    const NO_CERTIFICATE_RESERVED = 41;
+    const BAD_CERTIFICATE = 42;
+    const UNSUPPORTED_CERTIFICATE = 43;
+    const CERTIFICATE_REVOKED = 44;
+    const CERTIFICATE_EXPIRED = 45;
+    const CERTIFICATE_UNKNOWN = 46;
+    const ILLEGAL_PARAMETER = 47;
+    const UNKNOWN_CA = 48;
+    const ACCESS_DENIED = 49;
+    const DECODE_ERROR = 50;
+    const DECRYPT_ERROR = 51;
+    const EXPORT_RESTRICTION_RESERVED = 60;
+    const PROTOCOL_VERSION = 70;
+    const INSUFFICIENT_SECURITY = 71;
+    const INTERNAL_ERROR = 80;
+    const USER_CANCELED = 90;
+    const NO_RENEGOTIATION = 100;
+    const UNSUPPORTED_EXTENSION = 110;
+
+    // enum { warning(1), fatal(2), (255) } AlertLevel;
+    const LEVEL_WARNING = 1;
+    const LEVEL_FATAL = 2;
+
+    private $descCode;
+    private $level;
+    private $fromPeer;
+
+    public static function create($descCode, $level = self::LEVEL_FATAL)
+    {
+        $alert = new Alert();
+        $alert->descCode = $descCode;
+        $alert->level = $level;
+        $alert->fromPeer = false;
+
+        return $alert;
+    }
+
+    public static function getConst($value)
+    {
+        $class = new \ReflectionClass(__CLASS__);
+        $constants = array_flip($class->getConstants());
+
+        return $constants[$value];
+    }
+
+    public function getDescCode()
+    {
+        return $this->descCode;
+    }
+
+    public function fromPeer()
+    {
+        return $this->fromPeer;
+    }
+
+    public function encode($data)
+    {
+        $this->level = Core::_unpack('C', $data[0]);
+        $this->descCode = Core::_unpack('C', $data[1]);
+
+        // We got alert message from peer
+        $this->fromPeer = true;
+    }
+
+    public function decode()
+    {
+        return Core::_pack('C', $this->level)
+            . Core::_pack('C', $this->descCode);
+    }
+
+    public function toString()
+    {
+        $desc = $this->getConst($this->descCode);
+        $msg = $desc . " " . $this->descCode;
+
+        return $msg;
+    }
+
+    public function debugInfo()
+    {
+        $this->toString();
+    }
+}

--- a/libs/TLS/PTLS/Content/ApplicationData.php
+++ b/libs/TLS/PTLS/Content/ApplicationData.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace PTLS\Content;
+
+use PTLS\Core;
+use PTLS\ProtocolAbstract;
+
+class ApplicationData extends ProtocolAbstract
+{
+    private $core;
+
+    public function __construct(Core $core)
+    {
+        $this->core = $core;
+    }
+
+    public function encode($data)
+    {
+        $this->core->getBufferIn()->append($data);
+    }
+
+    public function decode()
+    {
+    }
+
+    public function debugInfo()
+    {
+        return "[ApplicationData]\n"
+            . "Data Length: " . $this->core->getBufferIn()->length();
+    }
+}

--- a/libs/TLS/PTLS/Content/ChangeCipherSpec.php
+++ b/libs/TLS/PTLS/Content/ChangeCipherSpec.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace PTLS\Content;
+
+use PTLS\Core;
+use PTLS\ProtocolAbstract;
+
+/**
+ * https://tools.ietf.org/html/rfc5246#section-7.1
+ *
+ *   The change cipher spec protocol exists to signal transitions in
+ *   ciphering strategies.  The protocol consists of a single message,
+ *   which is encrypted and compressed under the current (not the pending)
+ *   connection state.  The message consists of a single byte of value 1.
+ *
+ *      struct {
+ *          enum { change_cipher_spec(1), (255) } type;
+ *      } ChangeCipherSpec;
+ */
+class ChangeCipherSpec extends ProtocolAbstract
+{
+    public function encode($data)
+    {
+        $msg = Core::_unpack('C', $data[0]);
+    }
+
+    public function decode()
+    {
+        return Core::_pack('C', 0x01);
+    }
+
+    public function debugInfo()
+    {
+        return "[ChangeCipherSpec]\n";
+    }
+}

--- a/libs/TLS/PTLS/Content/ClientContent.php
+++ b/libs/TLS/PTLS/Content/ClientContent.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace PTLS\Content;
+
+use PTLS\Core;
+use PTLS\ContentType;
+use PTLS\Handshake\HandshakeType;
+use PTLS\Handshake\HandshakeFactory;
+use PTLS\Exceptions\TLSAlertException;
+
+class ClientContent extends ContentAbstract
+{
+    public function __construct(Core $core)
+    {
+        parent::__construct($core);
+
+        $recordOut = $core->getOutDuplex()->getRecord();
+        $bufferOut = $core->getBufferOut();
+
+        // ===========================================
+        // Send Client Hello
+        // ===========================================
+        $clientHello = HandshakeFactory::getInstance($core, HandshakeType::CLIENT_HELLO);
+        $payload = $clientHello->decode();
+
+        $bufferOut->set($this->decodeContent($payload, ContentType::HANDSHAKE));
+
+        $this->expectedHandshakeType = HandshakeType::SERVER_HELLO;
+    }
+
+    public function encodeHandshake($payload)
+    {
+        $core = $this->core;
+
+        // Incomming Record
+        $recordIn = $core->getInDuplex()->getRecord();
+
+        // Outgoing Record
+        $recordOut = $core->getOutDuplex()->getRecord();
+
+        // Buffer to send
+        $bufferOut = $core->getBufferOut();
+
+        // Extension
+        $extensions = $core->extensions;
+
+        if ($core->isHandshaked) {
+            throw new TLSAlertException(Alert::create(Alert::UNEXPECTED_MESSAGE),
+                "Handshake message received after handshake is complete");
+        }
+        /*
+         * https://tools.ietf.org/html/rfc5246#section-7.4
+         *
+         * Get Handshake Msg type
+         */
+        $handshakeType = Core::_unpack('C', $payload[0]);
+
+        if ($this->expectedHandshakeType != $handshakeType) {
+            throw new TLSAlertException(Alert::create(Alert::UNEXPECTED_MESSAGE),
+                "Unexpected handshake message: $handshakeType <=> " . $this->expectedHandshakeType);
+        }
+
+        $handshake = HandshakeFactory::getInstance($core, $handshakeType);
+
+        $handshake->encode($payload);
+
+        $this->content = $handshake;
+
+        switch ($this->expectedHandshakeType) {
+            case HandshakeType::SERVER_HELLO:
+                $this->expectedHandshakeType = HandshakeType::CERTIFICATE;
+                break;
+
+            case HandshakeType::CERTIFICATE:
+
+                if ($core->cipherSuite->isECDHEEnabled()) {
+                    $this->expectedHandshakeType = HandshakeType::SERVER_KEY_EXCHANGE;
+                } else {
+                    $this->expectedHandshakeType = HandshakeType::SERVER_HELLO_DONE;
+                }
+                break;
+
+            case HandshakeType::SERVER_KEY_EXCHANGE:
+                $this->expectedHandshakeType = HandshakeType::SERVER_HELLO_DONE;
+                break;
+
+            case HandshakeType::SERVER_HELLO_DONE:
+
+                // ===========================================
+                // Send Client Key Exchange
+                // ===========================================
+                $clientKeyExchange = HandshakeFactory::getInstance($core, HandshakeType::CLIENT_KEY_EXCHANGE);
+                $bufferOut->set($this->decodeContent($clientKeyExchange->decode(), ContentType::HANDSHAKE));
+
+                // ===========================================
+                // Send Change Cipher Spec
+                // ===========================================
+                $changeCipherSpec = new ChangeCipherSpec();
+
+                $bufferOut->append($this->decodeContent($changeCipherSpec->decode(), ContentType::CHANGE_CIPHER_SPEC));
+
+                // Enable encryption
+                $recordOut->cipherChanged();
+
+                // ===========================================
+                // Send Client finished
+                // ===========================================
+                $clientFinished = HandShakeFactory::getInstance($core, HandshakeType::FINISHED);
+
+                $bufferOut->append($this->decodeContent($clientFinished->decode(), ContentType::HANDSHAKE));
+
+                $this->expectedHandshakeType = HandshakeType::FINISHED;
+                break;
+
+            case HandshakeType::FINISHED:
+                $core->isHandshaked = true;
+                break;
+
+        }
+
+        if (strlen($payload) > $handshake->get('length')) {
+            $payload = substr($payload, $handshake->get('length'));
+            $this->encodeHandshake($payload);
+        }
+    }
+}

--- a/libs/TLS/PTLS/Content/ContentAbstract.php
+++ b/libs/TLS/PTLS/Content/ContentAbstract.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace PTLS\Content;
+
+use PTLS\Core;
+use PTLS\ContentType;
+use PTLS\Handshake\HandshakeType;
+use PTLS\Exceptions\TLSAlertException;
+use PTLS\Exceptions\TLSException;
+
+abstract class ContentAbstract
+{
+    protected $expectedHandshakeType;
+    protected $core;
+    protected $content;
+    protected $appData;
+
+    abstract public function encodeHandshake($data);
+
+    public function __construct(Core $core)
+    {
+        $this->core = $core;
+        $this->content =
+        $this->appData = null;
+    }
+
+    /**
+     * https://tools.ietf.org/html/rfc5246#section-6.2.1
+     *
+     *      enum {
+     *          change_cipher_spec(20), alert(21), handshake(22),
+     *          application_data(23), (255)
+     *      } ContentType;
+     */
+    public function encodeContent($contentType, $payload, $record)
+    {
+        $core = $this->core;
+
+        switch ($contentType) {
+            case ContentType::HANDSHAKE:
+
+                // Count handshake for later to create finished message
+                $core->countHandshakeMessages($payload);
+
+                $this->encodeHandshake($payload);
+                break;
+
+            case ContentType::CHANGE_CIPHER_SPEC:
+                $this->encodeChangeCipherSpec($payload);
+                $record->cipherChanged();
+                break;
+
+            case ContentType::ALERT:
+                $this->encodeAlert($payload);
+                break;
+
+            case ContentType::APPLICATION_DATA:
+                $this->encodeApplicationData($payload);
+                break;
+
+            /*
+             * https://tools.ietf.org/html/rfc5246#section-6
+             *
+             * If a TLS implementation receives an unexpected record type, it MUST send an
+             * unexpected_message alert.
+             */
+            default:
+                throw new TLSAlertException(Alert::create(Alert::UNEXPECTED_MESSAGE), "Unknow Content Type: $contentType");
+        }
+    }
+
+    protected function decodeContent($payload, $contentType)
+    {
+        $core = $this->core;
+
+        $recordOut = $core->getOutDuplex()->getRecord();
+
+        $out = $recordOut->set('contentType', $contentType)
+            ->set('payload', $payload)
+            ->decode();
+
+        return $out;
+    }
+
+    public function encodeChangeCipherSpec($data)
+    {
+        $core = $this->core;
+
+        if ($this->expectedHandshakeType != HandshakeType::FINISHED || $core->isHandshaked) {
+            throw new TLSException("Invalid message");
+        }
+
+        $changeCipherSpec = new ChangeCipherSpec();
+        $changeCipherSpec->encode($data);
+
+        $this->content = $changeCipherSpec;
+    }
+
+    public function encodeApplicationData($data)
+    {
+        $core = $this->core;
+
+        if (!$core->isHandshaked) {
+            throw new TLSException("Handshake Imcomplete");
+        }
+
+        if (is_null($this->appData)) {
+            $this->appData = new ApplicationData($this->core);
+        }
+
+        $this->appData->encode($data);
+    }
+
+    public function encodeAlert($data)
+    {
+        $core = $this->core;
+
+        $alert = new Alert();
+        $alert->encode($data);
+
+        $this->content = $alert;
+
+        $core->isClosed = true;
+
+        if ($alert->getDescCode() != Alert::CLOSE_NOTIFY) {
+            throw new TLSAlertException($alert, "Alert received from peer");
+        }
+    }
+
+    public function debugInfo()
+    {
+        if (is_null($this->content)) {
+            return;
+        }
+        return $this->content->debugInfo();
+    }
+}

--- a/libs/TLS/PTLS/Content/ServerContent.php
+++ b/libs/TLS/PTLS/Content/ServerContent.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace PTLS\Content;
+
+use PTLS\Core;
+use PTLS\ContentType;
+use PTLS\Handshake\HandshakeType;
+use PTLS\Handshake\HandshakeFactory;
+use PTLS\Exceptions\TLSAlertException;
+
+class ServerContent extends ContentAbstract
+{
+    public function __construct(Core $core)
+    {
+        $this->core = $core;
+        $this->expectedHandshakeType = HandshakeType::CLIENT_HELLO;
+    }
+
+    public function encodeHandshake($payload)
+    {
+        $core = $this->core;
+
+        // Incomming Record
+        $recordIn = $core->getInDuplex()->getRecord();
+
+        // Outgoing Record
+        $recordOut = $core->getOutDuplex()->getRecord();
+
+        // Buffer to send
+        $bufferOut = $core->getBufferOut();
+
+        // Extension
+        $extensions = $core->extensions;
+
+        /*
+         * https://tools.ietf.org/html/rfc5246#section-7.4
+         *
+         * Get Handshake Msg type
+         */
+        $handshakeType = Core::_unpack('C', $payload[0]);
+
+        if ($core->isHandshaked) {
+            throw new TLSAlertException(Alert::create(Alert::UNEXPECTED_MESSAGE),
+                "Handshake message received after handshake is complete: $handshakeType");
+        }
+
+        if ($this->expectedHandshakeType != $handshakeType) {
+            throw new TLSAlertException(Alert::create(Alert::UNEXPECTED_MESSAGE), "Unexpected handshake message");
+        }
+
+        $handshake = HandshakeFactory::getInstance($core, $handshakeType);
+
+        $handshake->encode($payload);
+
+        $this->content = $handshake;
+
+        // Set the response into bufferOut if any
+        switch ($this->expectedHandshakeType) {
+            case HandshakeType::CLIENT_HELLO:
+
+                // ===========================================
+                // Send Server Hello
+                // ===========================================
+                $serverHello = HandshakeFactory::getInstance($core, HandshakeType::SERVER_HELLO);
+
+                $bufferOut->set($this->decodeContent($serverHello->decode(), ContentType::HANDSHAKE));
+
+                // ===========================================
+                // Send Certificate
+                // ===========================================
+                $certificate = HandshakeFactory::getInstance($core, HandshakeType::CERTIFICATE);
+
+                $bufferOut->append($this->decodeContent($certificate->decode(), ContentType::HANDSHAKE));
+
+                // ===========================================
+                // Send Server Key Exchange
+                // ===========================================
+                if ($core->cipherSuite->isECDHEEnabled()) {
+                    $curveOut = $extensions->call('Curve', 'decodeServerKeyExchange', null);
+                    $bufferOut->append($this->decodeContent($curveOut, ContentType::HANDSHAKE));
+                }
+
+                // ===========================================
+                // Send Server Hello Done
+                // ===========================================
+                $serverHelloDone = HandshakeFactory::getInstance($core, HandshakeType::SERVER_HELLO_DONE);
+
+                $bufferOut->append($this->decodeContent($serverHelloDone->decode(), ContentType::HANDSHAKE));
+
+                // Update state
+                $this->expectedHandshakeType = HandshakeType::CLIENT_KEY_EXCHANGE;
+
+                break;
+
+            case HandshakeType::CLIENT_KEY_EXCHANGE:
+                $this->expectedHandshakeType = HandshakeType::FINISHED;
+                break;
+
+            case HandshakeType::FINISHED:
+
+                // ===========================================
+                // Send Change Cipher Spec
+                // ===========================================
+                $changeCipherSpec = new ChangeCipherSpec();
+
+                $bufferOut->set($this->decodeContent($changeCipherSpec->decode(), ContentType::CHANGE_CIPHER_SPEC));
+
+                // Enable encryption
+                $recordOut->cipherChanged();
+
+                // ===========================================
+                // Send Server finished
+                // ===========================================
+                $serverFinished = HandShakeFactory::getInstance($core, HandshakeType::FINISHED);
+
+                $bufferOut->append($this->decodeContent($serverFinished->decode(), ContentType::HANDSHAKE));
+
+                $core->isHandshaked = true;
+
+                break;
+        }
+
+        if (strlen($payload) > $handshake->get('length')) {
+            $payload = substr($payload, $handshake->get('length'));
+            $this->encodeHandshake($payload);
+        }
+    }
+}

--- a/libs/TLS/PTLS/ContentType.php
+++ b/libs/TLS/PTLS/ContentType.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace PTLS;
+
+/**
+ * https://tools.ietf.org/html/rfc5246#section-6.2
+ * 6.2.  Record Layer
+ *
+ *   The TLS record layer receives uninterpreted data from higher layers
+ *   in non-empty blocks of arbitrary size.
+ *
+ *    enum {
+ *          change_cipher_spec(20), alert(21), handshake(22),
+ *          application_data(23), (255)
+ *      } ContentType;
+ */
+class ContentType
+{
+    const CHANGE_CIPHER_SPEC = 20;
+    const ALERT = 21;
+    const HANDSHAKE = 22;
+    const APPLICATION_DATA = 23;
+
+    public static function getString($type)
+    {
+        switch ($type) {
+            case self::CHANGE_CIPHER_SPEC:
+                return "CHANGE_CIPHER_SPEC";
+            case self::ALERT:
+                return "ALERT";
+            case self::HANDSHAKE:
+                return "HANDSHAKE";
+            case self::APPLICATION_DATA:
+                return "APPLICATION_DATA";
+        }
+
+        return "UNKNOWN";
+    }
+}

--- a/libs/TLS/PTLS/Core.php
+++ b/libs/TLS/PTLS/Core.php
@@ -1,0 +1,290 @@
+<?php
+
+namespace PTLS;
+
+use PTLS\Buffer;
+use PTLS\Content\ClientContent;
+use PTLS\Content\ServerContent;
+use PTLS\ConnectionDuplex;
+use PTLS\Extensions\TLSExtensions;
+use PTLS\X509;
+use PTLS\Exceptions\TLSAlertException;
+use PTLS\Content\Alert;
+
+class Core
+{
+    public $isServer;
+
+    /**
+     * True when handshake is done and connection is established
+     */
+    public $isHandshaked;
+
+
+    /**
+     * True when alert message is received
+     */
+    public $isClosed;
+
+    /**
+     *  https://tools.ietf.org/html/rfc5246#appendix-A.5
+     *  The Cipher Suite
+     */
+    public $cipherSuite;
+
+    /**
+     * https://tools.ietf.org/html/rfc5246#section-5
+     *  HMAC and the Pseudorandom Function
+     */
+    public $prf;
+
+    /**
+     * https://tools.ietf.org/html/rfc5246#section-7.4.1.4
+     */
+    public $extensions;
+
+    /**
+     * https://tools.ietf.org/html/rfc5246#section-6.2.1
+     *
+     * Content Encoder
+     */
+    public $content;
+
+    private $config;
+
+    /**
+     * https://tools.ietf.org/html/rfc5246#appendix-A.1
+     *
+     * TLS Protocol Version
+     */
+    private $vMajor = null;
+    private $vMinor = null;
+
+    /**
+     *  Set default TLS version as 1.2
+     */
+    private $vMajorDefault = 3;
+    private $vMinorDefault = 3;
+    private $protocolVersion;
+
+    /**
+     * https://tools.ietf.org/html/rfc5246#section-7.4.7
+     *
+     * Client Key Exchange Message
+     */
+    private $masterSecret;
+
+    /**
+     * https://tools.ietf.org/html/rfc5246#section-7.4.9
+     * All of the data from all messages in this handshake (not
+     *     including any HelloRequest messages) up to, but not including,
+     *     this message.
+     *
+     * https://tools.ietf.org/html/rfc5246#section-7.4.1.1
+     * This message MUST NOT be included in the message hashes that are
+     * maintained throughout the handshake and used in the Finished messages
+     * and the certificate verify message
+     */
+    private $handshakeMessages;
+
+    /**
+     * https://tools.ietf.org/html/rfc5246#section-7 page 26
+     * session identifier
+     *   An arbitrary byte sequence chosen by the server to identify an
+     *  active or resumable session state.
+     */
+    private $sessionID;
+
+    /**
+     * No compression method for this library(null)
+     */
+    private $compressionMethod;
+
+    /**
+     * Certificates used by a server
+     */
+    private $crtDers;
+
+    private $server; // ConnectionDuplex
+    private $client; // ConnectionDuplex
+
+    private $bufferIn;
+    private $bufferOut; // Buffer
+
+    public function __construct($isServer, Config $config)
+    {
+        $this->config = $config;
+
+        $this->isHandshaked = false;
+        $this->isClosed = false;
+
+        $this->isServer = $isServer;
+
+        $this->server = new ConnectionDuplex($this);
+        $this->client = new ConnectionDuplex($this);
+
+        $this->handshakeMessages = '';
+
+        $this->bufferIn = new Buffer();
+        $this->bufferOut = new Buffer();
+
+        $this->extensions = new TLSExtensions($this);
+
+        // Compression Method - uncompressed
+        $this->compressionMethod = 0;
+
+        // Prf
+        $this->prf = new Prf($this);
+
+        $this->handshakeMessages = [];
+
+        if ($isServer) {
+            $this->crtDers = $this->config->get('crt_ders');
+            $this->content = new ServerContent($this);
+        } else { // Client
+            $this->content = new ClientContent($this);
+            $this->setVersion(3, $config->get('version', $this->vMinorDefault));
+        }
+    }
+
+    /**
+     * Getter and Setter
+     */
+    public function __call($name, $args)
+    {
+        if (strlen($name) < 3) {
+            throw new TLSAlertException(Alert::create(Alert::INTERNAL_ERROR), "Core::$name too short");
+        }
+
+        $properties = ['bufferIn', 'bufferOut', 'sessionID', 'compressionMethod', 'masterSecret', 'crtDers'];
+
+        $getOrSet = substr($name, 0, 3);
+
+        if ($getOrSet != 'get' && $getOrSet != 'set') {
+            throw new TLSAlertException(Alert::create(Alert::INTERNAL_ERROR), "Core::$name not exist");
+        }
+
+        $property = substr($name, 3);
+        $property[0] = strtolower($property[0]);
+
+        if (!in_array($property, $properties)) {
+            throw new TLSAlertException(Alert::create(Alert::INTERNAL_ERROR), "Core::$property not exist");
+        }
+
+        // Getter
+        if ($getOrSet == 'get') {
+            return $this->$property;
+        }
+
+        if (!isset($args[0])) {
+            throw new TLSAlertException(Alert::create(Alert::INTERNAL_ERROR), "No args set for Core::$property");
+        }
+
+        // Setter
+        $this->$property = $args[0];
+    }
+
+    public function getOutDuplex()
+    {
+        return ($this->isServer) ? $this->server : $this->client;
+    }
+
+    public function getInDuplex()
+    {
+        return ($this->isServer) ? $this->client : $this->server;
+    }
+
+    public function getProtocolVersion()
+    {
+        return $this->protocolVersion;
+    }
+
+    public function getVersion()
+    {
+        if ($this->vMajor == 0 || $this->vMinor == 0) {
+            return [$this->vMajorDefault, $this->vMinorDefault];
+        }
+
+        return [$this->vMajor, $this->vMinor];
+    }
+
+    public function setVersion($vMajor, $vMinor)
+    {
+        if ($vMajor != 3 || ($vMinor > 3 && $vMinor < 2)) {
+            throw new TLSAlertException(Alert::create(Alert::PROTOCOL_VERSION), "Unsupported Protocol $vMajor:$vMinor");
+        }
+
+        if (!is_null($this->protocolVersion)) {
+            return;
+        }
+
+        $this->vMajor = $vMajor;
+        $this->vMinor = $vMinor;
+
+        // TLS1.2
+        if ($this->vMinor == 3) {
+            $this->protocolVersion = 32;
+        } // TLS1.1
+        else {
+            $this->protocolVersion = 31;
+        }
+    }
+
+    /**
+     * All Handshake messages must be recorded
+     */
+    public function countHandshakeMessages($msg)
+    {
+        if ($this->isHandshaked) {
+            return;
+        }
+
+        $this->handshakeMessages[] = $msg;
+    }
+
+    public function getHandshakeMessages($sub = 0)
+    {
+        if ($sub != 0) {
+            $msg = implode('', array_slice($this->handshakeMessages, 0, count($this->handshakeMessages) - $sub));
+        } else {
+            $msg = implode('', $this->handshakeMessages);
+        }
+
+        return $msg;
+    }
+
+    public function getConfig($key)
+    {
+        return $this->config->get($key);
+    }
+
+    /**
+     *  Generate client/server random, IV, PreMaster for RSA Key Exchange
+     */
+    public static function getRandom($length)
+    {
+        $random = openssl_random_pseudo_bytes($length, $strong);
+
+        if (true !== $strong) {
+            throw new TLSAlertException(Alert::create(Alert::INTERNAL_ERROR), "Random byte not strong");
+        }
+
+        return $random;
+    }
+
+    public static function _unpack($f, $d)
+    {
+        $r = unpack($f, $d);
+
+        if (!is_array($r) || !isset($r[1])) {
+            throw new TLSAlertException(Alert::create(Alert::INTERNAL_ERROR), "unpack failed. format: $f, data: $d");
+        }
+
+        return $r[1];
+    }
+
+    public static function _pack($f, $d)
+    {
+        return pack($f, $d);
+    }
+}

--- a/libs/TLS/PTLS/DataConverterInterface.php
+++ b/libs/TLS/PTLS/DataConverterInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PTLS;
+
+interface DataConverterInterface
+{
+    /**
+     * Unserialize
+     */
+    public function encode($data);
+
+    /**
+     *  Serialize to TLS format
+     */
+    public function decode();
+}

--- a/libs/TLS/PTLS/Debug.php
+++ b/libs/TLS/PTLS/Debug.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace PTLS;
+
+class Debug
+{
+    private $core;
+
+    public function __construct(Core $core)
+    {
+        $this->core = $core;
+    }
+
+    public function getProtocolVersion()
+    {
+        list($vMajor, $vMinor) = $this->core->getVersion();
+        return "1." . ($vMinor - 1);
+    }
+
+    public function getCertificates()
+    {
+        $crtDers = $this->core->getCrtDers();
+
+        if (!count($crtDers)) {
+            return '';
+        }
+
+        $output = [];
+
+        foreach ($crtDers as $der) {
+            $output[] = X509::crtDerToPem($der);
+        }
+
+        return implode("\n", $output) . "\n";
+    }
+
+    public function getPrivateKey()
+    {
+        if (!$this->core->isServer) {
+            return;
+        }
+        $privateKeyPair = $this->core->getConfig('private_key');
+        $privateKey = X509::getPrivateKey($privateKeyPair[0], $privateKeyPair[1]);
+
+        return $privateKey;
+    }
+
+    public function getUsingCipherSuite()
+    {
+        if (is_null($this->core->cipherSuite)) {
+            return;
+        }
+
+        return $this->core->cipherSuite->debugInfo();
+    }
+
+    public function getSessionID()
+    {
+        return $this->core->getSessionID();
+    }
+
+    public function getMasterSecret()
+    {
+        return $this->core->getMasterSecret();
+    }
+
+    public function getRecordStatus()
+    {
+        $recordIn = $this->core->getInDuplex()->getRecord();
+        return "=================RecordStatus===================\n"
+            . $recordIn->debugInfo()
+            . "\n================================================\n";
+    }
+}

--- a/libs/TLS/PTLS/EcDH.php
+++ b/libs/TLS/PTLS/EcDH.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace PTLS;
+
+use Mdanter\Ecc\Crypto\EcDH\EcDH as MdanterEcDH;
+
+;
+
+use Mdanter\Ecc\EccFactory;
+use Mdanter\Ecc\Serializer\Point\UncompressedPointSerializer;
+use Mdanter\Ecc\Primitives\GeneratorPoint;
+use Mdanter\Ecc\Crypto\Key\PublicKey;
+
+/**
+ * https://tools.ietf.org/html/rfc4492#section-5.1.1
+ *
+ * enum {
+ *    sect163k1 (1), sect163r1 (2), sect163r2 (3),
+ *    sect193r1 (4), sect193r2 (5), sect233k1 (6),
+ *    sect233r1 (7), sect239k1 (8), sect283k1 (9),
+ *    sect283r1 (10), sect409k1 (11), sect409r1 (12),
+ *    sect571k1 (13), sect571r1 (14), secp160k1 (15),
+ *    secp160r1 (16), secp160r2 (17), secp192k1 (18),
+ *    secp192r1 (19), secp224k1 (20), secp224r1 (21),
+ *    secp256k1 (22), secp256r1 (23), secp384r1 (24),
+ *    secp521r1 (25),
+ *    reserved (0xFE00..0xFEFF),
+ *    arbitrary_explicit_prime_curves(0xFF01),
+ *    arbitrary_explicit_char2_curves(0xFF02),
+ *    (0xFFFF)
+ * } NamedCurve;
+ *
+ * ------------------------------------------
+ * We support below
+ * ------------------------------------------
+ * self::TYPE_SECP256R1 => secp256r1
+ * self::TYPE_SECP384R1 => secp384r1
+ *
+ */
+class EcDH
+{
+    const TYPE_SECP256R1 = 23;
+    const TYPE_SECP384R1 = 24;
+
+    public static $typeList = [
+        self::TYPE_SECP256R1,
+        self::TYPE_SECP384R1,
+    ];
+
+    private $ecdh;
+    private $curve;
+    private $gen;
+    private $privateKey;
+    private $publicKey;
+    private $adapter;
+
+    public static function isSupported($type)
+    {
+        switch ($type) {
+            case self::TYPE_SECP256R1:
+            case self::TYPE_SECP384R1:
+                return true;
+        }
+
+        return false;
+    }
+
+    public function __construct($type)
+    {
+        $this->type = $type;
+
+        $this->ecdh =
+        $this->curve =
+        $this->gen =
+        $this->privateKey =
+        $this->publicKey =
+        $this->adapter = null;
+    }
+
+    private function getGenerator()
+    {
+        if (!is_null($this->gen)) {
+            return $this->gen;
+        }
+
+        switch ($this->type) {
+            case self::TYPE_SECP256R1:
+                $gen = EccFactory::getSecgCurves()->generator256r1();
+                break;
+            case self::TYPE_SECP384R1:
+                $gen = EccFactory::getSecgCurves()->generator384r1();
+                break;
+
+            default:
+                return null;
+        }
+
+        $this->gen = $gen;
+        return $this->gen;
+    }
+
+    private function getCurve()
+    {
+        if (!is_null($this->curve)) {
+            return $this->curve;
+        }
+
+        switch ($this->type) {
+            case self::TYPE_SECP256R1:
+                $curve = EccFactory::getSecgCurves()->curve256r1();
+                break;
+            case self::TYPE_SECP384R1:
+                $curve = EccFactory::getSecgCurves()->curve384r1();
+                break;
+
+            default:
+                return null;
+        }
+
+        $this->curve = $curve;
+        return $this->curve;
+    }
+
+    private function getAdapter()
+    {
+        if (!is_null($this->adapter)) {
+            return $this->adapter;
+        }
+
+        $this->adapter = EccFactory::getAdapter();
+        return $this->adapter;
+    }
+
+    private function getEcdh()
+    {
+        if (!is_null($this->ecdh)) {
+            return $this->ecdh;
+        }
+
+        $adapter = $this->getAdapter();
+
+        $this->ecdh = new MdanterEcDH($adapter);
+        return $this->ecdh;
+    }
+
+    public function getPrivateKey()
+    {
+        if (!is_null($this->privateKey)) {
+            return $this->privateKey;
+        }
+
+        $gen = $this->getGenerator();;
+
+        $this->privateKey = $gen->createPrivateKey();
+
+        return $this->privateKey;
+    }
+
+    public function createPrivateKey()
+    {
+        $this->getPrivateKey();
+        return $this;
+    }
+
+    public function getPublicKey()
+    {
+        $privateKey = $this->getPrivateKey();
+
+        $this->publicKey = $publicKey = $privateKey->getPublicKey();
+
+        $publicPoint = $publicKey->getPoint();
+
+        // Convert to binary - Uncompressed
+        $publicKeyBin = Core::_pack('C', 0x04)
+            . gmp_export($publicPoint->getX(), 1, GMP_BIG_ENDIAN)
+            . gmp_export($publicPoint->getY(), 1, GMP_BIG_ENDIAN);
+
+        return $publicKeyBin;
+    }
+
+    public function calculateSharedKey($publicKeyBin)
+    {
+        $length = strlen($publicKeyBin) - 1;
+
+        if ($length % 2 != 0) {
+            return;
+        }
+
+        $half = $length / 2;
+
+        $x = substr($publicKeyBin, 1, $half);
+        $gmpX = gmp_import($x, 1);
+
+        $y = substr($publicKeyBin, $half + 1);
+        $gmpY = gmp_import($y, 1);
+
+        $curve = $this->getCurve();
+        $adapter = $this->getAdapter();
+        $gen = $this->getGenerator();
+        $ecdh = $this->getEcdh();
+
+        $point = $curve->getPoint($gmpX, $gmpY);
+
+        $privateKey = $this->getPrivateKey();
+        $publicKey = new PublicKey($adapter, $gen, $point);
+
+        $ecdh->setSenderKey($privateKey);
+        $ecdh->setRecipientKey($publicKey);
+
+        $sharedKey = $ecdh->calculateSharedKey();
+
+        return gmp_export($sharedKey);
+    }
+}

--- a/libs/TLS/PTLS/Exceptions/TLSAlertException.php
+++ b/libs/TLS/PTLS/Exceptions/TLSAlertException.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace PTLS\Exceptions;
+
+use PTLS\Core;
+use PTLS\Content\Alert;
+use PTLS\ContentType;
+
+class TLSAlertException extends \Exception
+{
+    private $alert;
+    private $output;
+
+    public function __construct(Alert $alert, $message)
+    {
+        $this->output = null;
+        $this->alert = $alert;
+        $message = $this->alert->toString() . " " . $message;
+        parent::__construct($message, $alert->getDescCode());
+    }
+
+    public function setOutput(Core $core)
+    {
+        $alert = $this->alert;
+
+        if ($alert->fromPeer()) {
+            return;
+        }
+
+        $recordOut = $core->getOutDuplex()->getRecord();
+
+        $payload = $alert->decode();
+
+        $this->output = $recordOut->set('contentType', ContentType::ALERT)
+            ->set('payload', $payload)
+            ->decode();
+    }
+
+    public function decode()
+    {
+        return $this->output;
+    }
+}

--- a/libs/TLS/PTLS/Exceptions/TLSException.php
+++ b/libs/TLS/PTLS/Exceptions/TLSException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PTLS\Exceptions;
+
+class TLSException extends \Exception
+{
+}

--- a/libs/TLS/PTLS/Extensions/Curve.php
+++ b/libs/TLS/PTLS/Extensions/Curve.php
@@ -1,0 +1,302 @@
+<?php
+
+namespace PTLS\Extensions;
+
+use PTLS\Core;
+use PTLS\Handshake\HandshakeFactory;
+use PTLS\Handshake\HandshakeType;
+use PTLS\EcDH;
+use PTLS\Exceptions\TLSAlertException;
+use PTLS\Content\Alert;
+
+/**
+ * https://tools.ietf.org/html/rfc4492#section-5.1
+ *
+ * enum { elliptic_curves(10), ec_point_formats(11) } ExtensionType;
+ *
+ *   elliptic_curves (Supported Elliptic Curves Extension):   Indicates
+ *      the set of elliptic curves supported by the client.  For this
+ *      extension, the opaque extension_data field contains
+ *      EllipticCurveList.  See Section 5.1.1 for details.
+ *
+ *   ec_point_formats (Supported Point Formats Extension):   Indicates the
+ *      set of point formats that the client can parse.  For this
+ *      extension, the opaque extension_data field contains
+ *      ECPointFormatList.  See Section 5.1.2 for details.
+ */
+class Curve extends ExtensionAbstract
+{
+    private $core;
+    private $namedCurveType;
+    private $isUncompressed;
+    private $ecdh;
+    private $preMaster;
+
+    public function __construct(Core $core)
+    {
+        $this->core = $core;
+        $this->isUncompressed = false;
+    }
+
+    public function isEnabled()
+    {
+        return $this->isUncompressed && !is_null($this->namedCurveType);
+    }
+
+    public function onEncodeClientHello($type, $data)
+    {
+        $core = $this->core;
+
+        switch ($type) {
+            /*
+             * elliptic_curves(10)
+             *
+             * https://tools.ietf.org/html/rfc4492#section-5.1.1
+             *
+             * struct {
+             *   NamedCurve elliptic_curve_list<1..2^16-1>
+             * } EllipticCurveList;
+             */
+            case TLSExtensions::TYPE_ELLIPTIC_CURVES:
+                $length = Core::_unpack('n', $data[0] . $data[1]);
+                $data = substr($data, 2);
+
+                for ($i = 0; $i < $length; $i += 2) {
+                    $namedCurveType = Core::_unpack('n', $data[$i] . $data[$i + 1]);
+
+                    if (Ecdh::isSupported($namedCurveType)) {
+                        $this->namedCurveType = $namedCurveType;
+                        break;
+                    }
+                }
+
+                break;
+
+            case TLSExtensions::TYPE_EC_POINT_FORMATS:
+                $this->encodeEcPointFormat($data);
+                break;
+        }
+    }
+
+    /**
+     * ec_point_formats(11)
+     *
+     * https://tools.ietf.org/html/rfc4492#section-5.1.2
+     *
+     * enum { uncompressed (0), ansiX962_compressed_prime (1),
+     *   ansiX962_compressed_char2 (2), reserved (248..255)
+     * } ECPointFormat;
+     *
+     * struct {
+     *   ECPointFormat ec_point_format_list<1..2^8-1>
+     * } ECPointFormatList;
+     *
+     * We ONLY support uncompressed(0)
+     */
+    private function encodeEcPointFormat($data)
+    {
+        $length = Core::_unpack('C', $data[0]);
+        $data = substr($data, 1);
+
+        for ($i = 0; $i < $length; $i++) {
+            $format = Core::_unpack('C', $data[$i]);
+            if ($format == 0) {
+                $this->isUncompressed = true;
+                break;
+            }
+        }
+    }
+
+    public function onEncodeServerHello($type, $data)
+    {
+        $core = $this->core;
+
+        if ($type != TLSExtensions::TYPE_EC_POINT_FORMATS) {
+            return;
+        }
+
+        $this->encodeEcPointFormat($data);
+    }
+
+    private function decodeEcPointFormat()
+    {
+        // ec_point_format - uncompressed
+        $data = Core::_pack('C', 1) . Core::_pack('C', 0);
+
+        $this->extType = TLSExtensions::TYPE_EC_POINT_FORMATS;
+        $this->length = strlen($data);
+
+        return $this->decodeHeader() . $data;
+    }
+
+    public function onDecodeClientHello()
+    {
+        // ec_point_format
+        $data = $this->decodeEcPointFormat();
+
+        // elliptic curves
+        $namedCurveTypes = '';
+
+        foreach (EcDH::$typeList as $namedCurveType) {
+            $namedCurveTypes .= Core::_pack('n', $namedCurveType);
+        }
+
+        $namedCurveData = Core::_pack('n', strlen($namedCurveTypes)) . $namedCurveTypes;
+
+        $this->extType = TLSExtensions::TYPE_ELLIPTIC_CURVES;
+        $this->length = strlen($namedCurveData);
+
+        $data .= $this->decodeHeader() . $namedCurveData;
+
+        return $data;
+    }
+
+    public function onDecodeServerHello()
+    {
+        if (!$this->isEnabled()) {
+            return;
+        }
+
+        return $this->decodeEcPointFormat();
+    }
+
+    public function encodeServerKeyExchange($data)
+    {
+        // Must turn true when onEncodeServerHello is called
+        //if( !$this->isUncompressed )
+        //    return;
+
+        $core = $this->core;
+        $hs = HandShakeFactory::getInstance($core, HandshakeType::SERVER_KEY_EXCHANGE);
+
+        $data = $hs->encodeHeader($data);
+
+        $length = $hs->get('length');
+
+        $curveType = Core::_unpack('C', $data[0]);
+
+        if ($curveType != 0x03) {
+            throw new TLSAlertException(Alert::create(Alert::INTERNAL_ERROR),
+                "Not named curve type: " + $curveType);
+        }
+
+        $namedCurveType = Core::_unpack('n', $data[1] . $data[2]);
+
+        if (!EcDH::isSupported($namedCurveType)) {
+            throw new TLSAlertException(Alert::create(Alert::INTERNAL_ERROR),
+                "Unknow named curve: " + $namedCurveType);
+        }
+
+        $this->namedCurveType = $namedCurveType;
+
+        $this->ecdh = new EcDH($this->namedCurveType);
+
+        $publicKeyLen = Core::_unpack('C', $data[3]);
+        $data = substr($data, 4);
+
+        $publicKeyBin = substr($data, 0, $publicKeyLen);
+
+        // Calculate and set premaster
+        $this->calculatePremaster($publicKeyBin);
+
+        // TODO verify signature
+    }
+
+    public function decodeClientKeyExchange()
+    {
+        $core = $this->core;
+        $publicKey = $this->getSenderPublicKey();
+        $data = Core::_pack('C', strlen($publicKey)) . $publicKey;
+
+        return $data;
+    }
+
+    public function decodeServerKeyExchange()
+    {
+        $core = $this->core;
+        $extensions = $core->extensions;
+
+        $protoVersion = $core->getProtocolVersion();
+
+        /*
+         * ECCurveType
+         *
+         * We only support named curves, which is 0x03
+         *
+         * enum { explicit_prime (1), explicit_char2 (2),
+         *        named_curve (3), reserved(248..255) } ECCurveType;
+         */
+        $data = Core::_pack('C', 0x03);
+
+        // Named curve type
+        $data .= Core::_pack('n', $this->namedCurveType);
+
+        // ECDH Public Key
+        $this->ecdh = new EcDH($this->namedCurveType);
+        $dataPublicKey = $this->ecdh->getPublicKey();
+
+        $data .= Core::_pack('C', strlen($dataPublicKey)) . $dataPublicKey;
+
+        /*
+          * Signature
+          *
+          * https://tools.ietf.org/html/rfc4492 Page 19
+          * signed_params:   A hash of the params, with the signature appropriate
+          * to that hash applied.  The private key corresponding to the
+          * certified public key in the server's Certificate message is used
+          * for signing.
+          *
+          * ServerKeyExchange.signed_params.sha_hash
+          *    SHA(ClientHello.random + ServerHello.random +
+          *                                      ServerKeyExchange.params);
+         */
+        $connIn = $core->getInDuplex();
+        $connOut = $core->getOutDuplex();
+
+        $dataSign = $connIn->random . $connOut->random . $data;
+
+        $signature = $extensions->call('SignatureAlgorithm', 'getSignature', null, $dataSign);
+
+        if ($protoVersion >= 32) {
+            // Signature Hash Alogorithm
+            // [null, null] never happens
+            list($hash, $sig) = $extensions->call('SignatureAlgorithm', 'getAlgorithm', [null, null]);
+            $data .= Core::_pack('C', $hash) . Core::_pack('C', $sig);
+        }
+
+        // Append signature
+        $data .= Core::_pack('n', strlen($signature)) . $signature;
+
+        $hs = HandShakeFactory::getInstance($core, HandshakeType::SERVER_KEY_EXCHANGE);
+
+        $hs->setMsgType(HandshakeType::SERVER_KEY_EXCHANGE);
+        $hs->set('length', strlen($data));
+
+        return $hs->getBinHeader() . $data;
+    }
+
+    /**
+     * https://tools.ietf.org/html/rfc4492#section-2
+     * Called from HandshakeClientKeyExchange
+     */
+    public function calculatePremaster($publicKeyBin)
+    {
+        $ecdh = $this->ecdh;
+        $sharedKey = $ecdh->calculateSharedKey($publicKeyBin);
+
+        $this->preMaster = $sharedKey;
+
+        return $sharedKey;
+    }
+
+    public function getPremaster()
+    {
+        return $this->preMaster;
+    }
+
+    public function getSenderPublicKey()
+    {
+        $ecdh = $this->ecdh;
+        return $ecdh->getPublicKey();
+    }
+}

--- a/libs/TLS/PTLS/Extensions/ExtensionAbstract.php
+++ b/libs/TLS/PTLS/Extensions/ExtensionAbstract.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace PTLS\Extensions;
+
+use PTLS\Core;
+
+abstract class ExtensionAbstract
+{
+    private $core;
+    protected $extType;
+    protected $legnth;
+
+    public function __construct(Core $core)
+    {
+        $this->core = $core;
+    }
+
+    protected function decodeHeader()
+    {
+        // MsgType
+        $header = Core::_pack('C', 0)
+            . Core::_pack('C', $this->extType)
+            // Length
+            . Core::_pack('n', $this->length);
+
+        return $header;
+    }
+
+    abstract public function onEncodeClientHello($type, $data);
+
+    abstract public function onDecodeClientHello();
+
+    abstract public function onDecodeServerHello();
+}

--- a/libs/TLS/PTLS/Extensions/SignatureAlgorithm.php
+++ b/libs/TLS/PTLS/Extensions/SignatureAlgorithm.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace PTLS\Extensions;
+
+use PTLS\Core;
+use PTLS\X509;
+
+/**
+ * https://tools.ietf.org/html/rfc5246#section-7.4.1.4.1
+ *
+ * The client uses the "signature_algorithms" extension to indicate to
+ *   the server which signature/hash algorithm pairs may be used in
+ *   digital signatures.  The "extension_data" field of this extension
+ *   contains a "supported_signature_algorithms" value.
+ *
+ *      enum {
+ *          none(0), md5(1), sha1(2), sha224(3), sha256(4), sha384(5),
+ *          sha512(6), (255)
+ *      } HashAlgorithm;
+ *
+ *      enum { anonymous(0), rsa(1), dsa(2), ecdsa(3), (255) }
+ *        SignatureAlgorithm;
+ *
+ *      struct {
+ *            HashAlgorithm hash;
+ *            SignatureAlgorithm signature;
+ *      } SignatureAndHashAlgorithm;
+ *
+ *      SignatureAndHashAlgorithm
+ *        supported_signature_algorithms<2..2^16-2>;
+ */
+class SignatureAlgorithm extends ExtensionAbstract
+{
+    const TYPE_DEFAULT_RSA = 0x0201; //sha1 rsa
+    const TYPE_SHA512_RSA = 0x0601;
+    const TYPE_SHA384_RSA = 0x0501;
+    const TYPE_SHA256_RSA = 0x0401;
+
+    private static $supportedAlgorithmList = [
+        self::TYPE_SHA512_RSA,
+        self::TYPE_SHA384_RSA,
+        self::TYPE_SHA256_RSA,
+    ];
+    private $core;
+    private $algorithm;
+
+    public function __construct(Core $core)
+    {
+        $this->core = $core;
+        $this->algorithm = null;
+    }
+
+    public function onEncodeClientHello($type, $data)
+    {
+        $core = $this->core;
+
+        if ($type != TLSExtensions::TYPE_SIGNATURE_ALGORITHM) {
+            return;
+        }
+
+        $protoVersion = $core->getProtocolVersion();
+
+        /*
+         *   Note: this extension is not meaningful for TLS versions prior to 1.2.
+         * Clients MUST NOT offer it if they are offering prior versions.
+         * However, even if clients do offer it, the rules specified in [TLSEXT]
+         * require servers to ignore extensions they do not understand.
+         */
+        if ($protoVersion < 32) {
+            return;
+        }
+
+        $length = Core::_unpack('n', $data[0] . $data[1]);
+        $data = substr($data, 2);
+
+        for ($i = 0; $i < $length; $i += 2) {
+            $hash = Core::_unpack('C', $data[$i]);
+            $sig = Core::_unpack('C', $data[$i + 1]);
+
+            $algorithm = $hash << 8 | $sig;
+
+            if (in_array($algorithm, self::$supportedAlgorithmList)) {
+                $this->algorithm = $algorithm;
+                break;
+            }
+        }
+    }
+
+    public function onDecodeClientHello()
+    {
+        $sigData = '';
+
+        foreach (self::$supportedAlgorithmList as $algorithm) {
+            $sigData .= Core::_pack('C', $algorithm >> 8) . Core::_pack('C', $algorithm & 0x00ff);
+        }
+
+        $sigData = Core::_pack('n', strlen($sigData)) . $sigData;
+
+        $this->extType = TLSExtensions::TYPE_SIGNATURE_ALGORITHM;
+        $this->length = strlen($sigData);
+
+        $data = $this->decodeHeader() . $sigData;
+
+        return $data;
+    }
+
+    public function onDecodeServerHello()
+    {
+    }
+
+    public function getAlgorithm()
+    {
+        $algorithm = is_null($this->algorithm) ? self::TYPE_DEFAULT_RSA : $this->algorithm;
+        return [$algorithm >> 8, $algorithm & 0x00ff];
+    }
+
+    /**
+     * Our version of md5sha1 signature as openssl doesn't support it
+     */
+    public function getSignatureMD5Sha1($dataSign, &$signature, $privateKey)
+    {
+        $hash = md5($dataSign, true) . sha1($dataSign, true);
+        openssl_private_encrypt($hash, $signature, $privateKey);
+    }
+
+    public function getSignature($dataSign)
+    {
+        $core = $this->core;
+        //$privateKey = $core->getConfig('private_key');
+        $privateKeyPair = $core->getConfig('private_key');
+        //var_dump($privateKeyPair);
+        $privateKey = X509::getPrivateKey($privateKeyPair[0], $privateKeyPair[1]);
+        //var_dump($privateKey);
+        $protoVersion = $core->getProtocolVersion();
+
+        /*
+         * https://www.ietf.org/rfc/rfc2246.txt page 40
+         *
+         * select (SignatureAlgorithm)
+         * {   case anonymous: struct { };
+         *   case rsa:
+         *       digitally-signed struct {
+         *           opaque md5_hash[16];
+         *           opaque sha_hash[20];
+         *       };
+         *   case dsa:
+         *       digitally-signed struct {
+         *           opaque sha_hash[20];
+         *       };
+         * } Signature;
+         */
+        if ($protoVersion < 32) {
+            $this->getSignatureMD5Sha1($dataSign, $signature, $privateKey);
+            return $signature;
+        }
+
+        /*
+         * https://tools.ietf.org/html/rfc5246#section-7.4.1.4.1
+         *
+         * If the client does not send the signature_algorithms extension, the
+         * server MUST do the following:
+         *
+         * -  If the negotiated key exchange algorithm is one of (RSA, DHE_RSA,
+         *    DH_RSA, RSA_PSK, ECDH_RSA, ECDHE_RSA), behave as if client had
+         *    sent the value {sha1,rsa}.
+         */
+        if (is_null($this->algorithm)) {
+            $ret = @openssl_sign($dataSign, $signature, $privateKey, OPENSSL_ALGO_SHA1);
+            if ($ret) {
+                return $signature;
+            }
+            throw new \PTLS\Exceptions\TLSException('Key invalid');
+        }
+
+        switch ($this->algorithm) {
+            case self::TYPE_SHA512_RSA:
+                $ret = @openssl_sign($dataSign, $signature, $privateKey, OPENSSL_ALGO_SHA512);
+                break;
+            case self::TYPE_SHA384_RSA:
+                $ret = @openssl_sign($dataSign, $signature, $privateKey, OPENSSL_ALGO_SHA384);
+                break;
+            case self::TYPE_SHA256_RSA:
+                $ret = @openssl_sign($dataSign, $signature, $privateKey, OPENSSL_ALGO_SHA256);
+                break;
+            default:
+                $ret = false;
+        }
+        if ($ret) {
+            return $signature;
+        }
+
+        throw new \PTLS\Exceptions\TLSException('Key invalid');
+    }
+}

--- a/libs/TLS/PTLS/Extensions/TLSExtensions.php
+++ b/libs/TLS/PTLS/Extensions/TLSExtensions.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace PTLS\Extensions;
+
+use PTLS\Core;
+
+/**
+ * https://tools.ietf.org/html/rfc5246#section-7.4.1.4
+ * Hello Extensions
+ */
+class TLSExtensions
+{
+    const TYPE_ELLIPTIC_CURVES = 10;
+    const TYPE_EC_POINT_FORMATS = 11;
+    const TYPE_SIGNATURE_ALGORITHM = 13;
+
+    public static $supportedList = [
+        self::TYPE_ELLIPTIC_CURVES => 'Curve',
+        self::TYPE_EC_POINT_FORMATS => 'Curve',
+        self::TYPE_SIGNATURE_ALGORITHM => 'SignatureAlgorithm',
+    ];
+
+    private $core;
+    private $instances;
+
+    public function __construct($core)
+    {
+        $this->core = $core;
+        $this->instances = [];
+
+        foreach (self::$supportedList as $type => $className) {
+            if (isset($this->instances[$className])) {
+                continue;
+            }
+
+            $this->instances[$className] = $this->getExtension($type);
+        }
+    }
+
+    private function getExtension($type)
+    {
+        switch ($type) {
+            case self::TYPE_ELLIPTIC_CURVES:
+            case self::TYPE_EC_POINT_FORMATS:
+                return new Curve($this->core);
+            case self::TYPE_SIGNATURE_ALGORITHM:
+                return new SignatureAlgorithm($this->core);
+        }
+
+        return null;
+    }
+
+    private function onEncode($method, $extensions)
+    {
+        // $extensions[] = ['type' => $extType, 'data' => $extData];
+        foreach ($extensions as $extension) {
+            if (!isset($extension['type']) || !isset($extension['data'])) {
+                throw new Exception("Invalid Extension Paramenter");
+            }
+
+            $type = $extension['type'];
+            $data = $extension['data'];
+
+            if (array_key_exists($type, self::$supportedList)) {
+                $className = self::$supportedList[$type];
+
+                if (!isset($this->instances[$className])) {
+                    $this->instances[$className] = $this->getExtension($type);
+                }
+
+                $ins = $this->instances[$className];
+
+                if (!$ins instanceof ExtensionAbstract) {
+                    throw new Exception("Not ExtensionAbstract");
+                }
+                call_user_func([$ins, $method], $type, $data);// fix php 5.6
+                //[$ins, $method]($type, $data);
+            }
+        }
+    }
+
+    private function onDecode($method)
+    {
+        $out = '';
+
+        if (!count($this->instances)) {
+            return $out;
+        }
+
+        foreach ($this->instances as $className => $ins) {
+            //$out .= [$ins, $method]();
+            $out .= call_user_func([$ins, $method]); // fix php 5.6
+        }
+
+        return $out;
+    }
+
+    public function __call($method, $args)
+    {
+        if (false !== strpos($method, 'onEncode')) {
+            return $this->onEncode($method, $args[0]);
+        }
+
+        if (false !== strpos($method, 'onDecode')) {
+            return $this->onDecode($method);
+        }
+    }
+
+    /**
+     * API call
+     */
+    public function call($className, $method, $default, ...$args)
+    {
+        if (isset($this->instances[$className]) &&
+            is_callable([$this->instances[$className], $method])) {
+            return call_user_func([$this->instances[$className], $method], ...$args);
+//            return [$this->instances[$className], $method](...$args);
+        }
+
+        return $default;
+    }
+}

--- a/libs/TLS/PTLS/Handshake/Certificate.php
+++ b/libs/TLS/PTLS/Handshake/Certificate.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace PTLS\Handshake;
+
+use PTLS\Core;
+
+class Certificate extends HandshakeAbstract
+{
+    public function __construct(Core $core)
+    {
+        parent::__construct($core);
+    }
+
+    public function encode($data)
+    {
+        $core = $this->core;
+
+        $data = $this->encodeHeader($data);
+
+        $crtsLength = Core::_unpack('N', $data[0] . $data[1] . $data[2] . 0x00) >> 8;
+        $crtsData = substr($data, 3, $crtsLength);
+
+        for ($i = 0; $i < $crtsLength;) {
+            $crtLength = Core::_unpack('n', $crtsData[$i + 1] . $crtsData[$i + 2]);
+            if (0 >= (int)$crtLength) {
+                break;
+            }
+
+            $crtDers[] = substr($crtsData, $i + 3, $crtLength);
+
+            $i += $crtLength + 3;
+        }
+
+        $core->setCrtDers($crtDers);
+    }
+
+    public function decode()
+    {
+        $core = $this->core;
+        $crtDers = $core->getCrtDers();
+
+        $crtData = '';
+
+        foreach ($crtDers as $crtDer) {
+            $crtLength = strlen($crtDer);
+
+            // Cert Length
+            $crtData .= Core::_pack('C', 0x00)
+                . Core::_pack('n', $crtLength)
+                . $crtDer;
+        }
+
+        $data = Core::_pack('C', 0x00)
+            . Core::_pack('n', strlen($crtData))
+            . $crtData;
+
+        $this->msgType = HandshakeType::CERTIFICATE;
+        $this->length = strlen($data);
+
+        return $this->getBinHeader() . $data;
+    }
+
+    public function debugInfo()
+    {
+        $core = $this->core;
+        $crtDers = $core->getCrtDers();
+
+        return "[HandshakeType::Certificate]\n"
+            . "Lengh:                   " . $this->length . "\n"
+            . "Number of Certificates:  " . count($crtDers) . "\n";
+    }
+}

--- a/libs/TLS/PTLS/Handshake/ClientHello.php
+++ b/libs/TLS/PTLS/Handshake/ClientHello.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace PTLS\Handshake;
+
+use PTLS\Core;
+use PTLS\Prf;
+use PTLS\CipherSuites;
+use PTLS\Exceptions\TLSAlertException;
+use PTLS\Content\Alert;
+
+class ClientHello extends HandshakeAbstract
+{
+    /**
+     * For Debug
+     */
+    private $requestedExtensions;
+    private $requestCipherIDs;
+
+    public function __construct(Core $core)
+    {
+        parent::__construct($core);
+    }
+
+    /**
+     * Client Hello
+     * https://tools.ietf.org/html/rfc5246#section-7.4.1.2
+     */
+    public function encode($data)
+    {
+        $core = $this->core;
+        $connIn = $core->getInDuplex();
+
+        $data = $this->encodeHeader($data);
+
+        // https://tools.ietf.org/html/rfc5246#section-7.4.1.2
+        $vMajor = $major = Core::_unpack('C', $data[0]);
+        $vMinor = $minor = Core::_unpack('C', $data[1]);
+
+        // Set TLS Version
+        $core->setVersion($vMajor, $vMinor);
+
+        // Get and set Client Random
+        $random = substr($data, 2, 32);
+
+        $connIn->random = $random;
+
+        $sessionLength = Core::_unpack('C', $data[34]);
+
+        $data = substr($data, 35);
+
+        // SessionID if > 0
+        if ($sessionLength > 0) {
+            $sessionID = substr($data, 0, $sessionLength);
+            $core->setSessionID($sessionID);
+            $data = substr($data, $sessionLength);
+        }
+
+        $cipherLength = Core::_unpack('n', $data[0] . $data[1]);
+
+        $data = substr($data, 2);
+
+        $cipherIDs = [];
+
+        // https://github.com/pornin/TestSSLServer/blob/master/Src/CipherSuite.cs
+        for ($i = 0; $i < $cipherLength; $i += 2) {
+            // https://tools.ietf.org/html/rfc5246#section-7.4.1.2
+            $cipher1 = Core::_unpack('C', $data[$i]);
+            $cipher2 = Core::_unpack('C', $data[$i + 1]);
+
+            $cipherIDs[] = [$cipher1, $cipher2];
+        }
+
+        $this->requestCipherIDs = $cipherIDs;
+
+        $data = substr($data, $cipherLength);
+
+        $compressionLength = Core::_unpack('C', $data[0]);
+        $compressionMethod = Core::_unpack('C', $data[1]);
+
+        if ($compressionMethod != 0x00) {
+            throw new TLSAlertException(Alert::create(Alert::HANDSHAKE_FAILURE), "compressionMethod is not null");
+        }
+
+        $core->setCompressionMethod($compressionMethod);
+
+        // Extensions
+        $extLength = Core::_unpack('n', $data[2] . $data[3]);
+
+        $data = substr($data, 4, $extLength);
+
+        $this->requestedExtensions = $extensions = $this->encodeExtensions($data);
+
+        $core->extensions->onEncodeClientHello($extensions);
+
+        $cipherID = CipherSuites::pickCipherID($core, $cipherIDs);
+
+        if (is_null($cipherID)) {
+            throw new TLSAlertException(Alert::create(Alert::INTERNAL_ERROR), "Cipher Suite not found");
+        }
+
+        $core->cipherSuite = new CipherSuites($cipherID);
+    }
+
+    public function decode()
+    {
+        $core = $this->core;
+        $connOut = $core->getOutDuplex();
+
+        list($vMajor, $vMinor) = $core->getVersion();
+
+        // Set client random
+        $connOut->random = Core::getRandom(32);
+
+        // Set TLS Version
+        $data = Core::_pack('C', $vMajor) . Core::_pack('C', $vMinor);
+
+        // Client Random
+        $data .= $connOut->random;
+
+        // Session ID - no session
+        $data .= Core::_pack('C', 0x00);
+
+        // Cipher Suite
+        $cipherSuiteList = CipherSuites::decodeCipherList();
+
+        $data .= Core::_pack('n', strlen($cipherSuiteList)) . $cipherSuiteList;
+
+        // Compression method
+        $data .= Core::_pack('C', 0x01) . Core::_pack('C', $core->getCompressionMethod());
+
+        // Extension Length
+        //$data .= Core::_pack('n', 0x00);
+        $extensionData = $core->extensions->onDecodeClientHello();
+        $data .= Core::_pack('n', strlen($extensionData)) . $extensionData;
+
+        $this->msgType = HandshakeType::CLIENT_HELLO;
+        $this->length = strlen($data);
+        return $this->getBinHeader() . $data;
+    }
+
+    public function debugInfo()
+    {
+        /*
+         * struct {
+         *  ProtocolVersion client_version;
+         *  Random random;
+         *  SessionID session_id;
+         *  CipherSuite cipher_suites<2..2^16-2>;
+         *  CompressionMethod compression_methods<1..2^8-1>;
+         *  select (extensions_present) {
+         *      case false:
+         *          struct {};
+         *      case true:
+         *          Extension extensions<0..2^16-1>;
+         *  };
+         * } ClientHello;
+         */
+        $core = $this->core;
+        $connIn = $this->core->getInDuplex();
+
+        $protoVersion = $core->getProtocolVersion();
+        $sessionID = base64_encode($core->getSessionID());
+        $compressionMethod = $core->getCompressionMethod();
+
+        $cipherSuites = [];
+
+        // [$cipher1 , $cipher2]
+        foreach ($this->requestCipherIDs as $value) {
+            $cipherSuites[] = "0x" . dechex($value[0]) . dechex($value[1]);
+        }
+
+        $extensions = [];
+
+        // ['type' => $extType, 'data' => $extData]
+        foreach ($this->requestedExtensions as $value) {
+            $extensions[] = "Type: " . dechex($value['type'])
+                . ' Data Length: ' . strlen($value['data']);
+        }
+
+        return "[HandshakeType::ServerHello]\n"
+            . "Lengh:            " . $this->length . "\n"
+            . "Protocol Version: $protoVersion \n"
+            . "Session ID:       $sessionID \n"
+            . "[CipherSuites]\n"
+            . implode("\n", $cipherSuites) . "\n"
+            . "[Extensions]\n"
+            . implode("\n", $extensions);
+    }
+}

--- a/libs/TLS/PTLS/Handshake/ClientKeyExchange.php
+++ b/libs/TLS/PTLS/Handshake/ClientKeyExchange.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace PTLS\Handshake;
+
+use PTLS\Core;
+use PTLS\X509;
+use PTLS\Exceptions\TLSAlertException;
+use PTLS\Content\Alert;
+
+class ClientKeyExchange extends HandshakeAbstract
+{
+    public function __construct(Core $core)
+    {
+        parent::__construct($core);
+    }
+
+    private function setKeys($preMaster, $connServer, $connClient)
+    {
+        $core = $this->core;
+        $prf = $core->prf;
+
+        // https://tools.ietf.org/html/rfc5246#section-8.1
+        // Get a master secret from premaster
+        $clientRandom = $connClient->random;
+        $serverRandom = $connServer->random;
+
+        $masterSecret = $prf->getMaster($preMaster, $clientRandom, $serverRandom);
+        $secretKeys = $prf->getKeys($masterSecret, $clientRandom, $serverRandom);
+
+        $core->setMasterSecret($masterSecret);
+
+        // Set Secret keys
+        $connClient->setSecretKeys($secretKeys['client']);
+        $connServer->setSecretKeys($secretKeys['server']);
+    }
+
+    public function encode($data)
+    {
+        $core = $this->core;
+        $extensions = $core->extensions;
+
+        // Client
+        $connIn = $core->getInDuplex();
+
+        // Server
+        $connOut = $core->getOutDuplex();
+
+        $data = $this->encodeHeader($data);
+
+        // ECDHE
+        if ($core->cipherSuite->isECDHEEnabled()) {
+            $publicKeyLen = Core::_unpack('C', $data[0]);
+            $publicKey = substr($data, 1, $publicKeyLen);
+
+            $preMaster = $extensions->call('Curve', 'calculatePreMaster', null, $publicKey);
+        } // RSA
+        else {
+            // https://tools.ietf.org/html/rfc5246#section-7.4.7.1
+            // Get a Premaster Secret
+            $preMasterLen = Core::_unpack('n', $data[0] . $data[1]);
+
+            $encPreMaster = substr($data, 2, $preMasterLen);
+
+            //$privateKey = $core->getConfig('private_key');
+            $privateKeyPair = $core->getConfig('private_key');
+            $privateKey = X509::getPrivateKey($privateKeyPair[0], $privateKeyPair[1]);
+            openssl_private_decrypt($encPreMaster, $preMaster, $privateKey);
+
+            $vMajor = Core::_unpack('C', $preMaster[0]);
+            $vMinor = Core::_unpack('C', $preMaster[1]);
+
+            list($vMajor2, $vMinor2) = $core->getVersion();
+
+            if ($vMajor != $vMajor2 || $vMinor != $vMinor) {
+                throw new TLSAlertException(Alert::create(Alert::BAD_RECORD_MAC), "Invalid protocol version in PreMaster $vMajor <=> $vMajor2, $vMinor <=> $vMinor2");
+            }
+        }
+
+        $this->setKeys($preMaster, $connOut, $connIn);
+    }
+
+    public function decode()
+    {
+        $core = $this->core;
+
+        list($vMajor, $vMinor) = $core->getVersion();
+
+        // Client
+        $connOut = $core->getOutDuplex();
+
+        // Server
+        $connIn = $core->getInDuplex();
+
+        // ECDHE
+        if ($core->cipherSuite->isECDHEEnabled()) {
+            $extensions = $core->extensions;
+            $data = $extensions->call('Curve', 'decodeClientKeyExchange', '');
+
+            $preMaster = $extensions->call('Curve', 'getPremaster', null);
+        } // RSA
+        else {
+            $preMaster = Core::_pack('C', $vMajor)
+                . Core::_pack('C', $vMinor)
+                . Core::getRandom(46);
+
+            $crtDers = $core->getCrtDers();
+            $publicKey = X509::getPublicKey($crtDers);
+            openssl_public_encrypt($preMaster, $encPreMaster, $publicKey);
+
+            $data = Core::_pack('n', strlen($encPreMaster))
+                . $encPreMaster;
+        }
+
+        // Set Master Secret, IV and MAC
+        $this->setKeys($preMaster, $connIn, $connOut);
+
+        $this->msgType = HandshakeType::CLIENT_KEY_EXCHANGE;
+        $this->length = strlen($data);
+
+        return $this->getBinHeader() . $data;
+    }
+
+    public function debugInfo()
+    {
+        $connOut = $core->getOutDuplex();
+        $connIn = $core->getInDuplex();
+
+        foreach (['OUT' => $connOut, 'IN' => $connIn] as $key => $conn) {
+            $arr[$key] = [
+                'Random' => base64_encode($conn->random),
+                'CipherChanged' => (($conn->isCipherChanged) ? 'True' : 'False'),
+                'Key' => ('MAC:       ' . base64_encode($connOut->MAC)
+                    . 'IV:        ' . base64_encode($connOut->IV)
+                    . 'MasterKEY: ' . base64_encode($connOut->Key)),
+            ];
+        }
+
+        $output = 'IN:  ' . explode("\n", $arr['IN']) . "\n"
+            . 'OUT: ' . explode("\n", $arr['OUT']) . "\n";
+
+        return "[HandshakeType::ClientKeyExchange]\n"
+            . "Lengh:                   " . $this->length . "\n"
+            . $output;
+    }
+}

--- a/libs/TLS/PTLS/Handshake/Finished.php
+++ b/libs/TLS/PTLS/Handshake/Finished.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace PTLS\Handshake;
+
+use PTLS\Core;
+use PTLS\Exceptions\TLSAlertException;
+use PTLS\Content\Alert;
+
+class Finished extends HandshakeAbstract
+{
+    const PRF_LENGTH = 12;
+
+    public function __construct(Core $core)
+    {
+        parent::__construct($core);
+    }
+
+    private function getVerifyData($isServer = false, $handshakeMessages)
+    {
+        $core = $this->core;
+
+        $protoVersion = $core->getProtocolVersion();
+
+        $finishedLabel = ($isServer) ? "server finished" : "client finished";
+        $prf = $core->prf;
+
+        /*
+         * [TLS 1.1]
+         * https://www.ietf.org/rfc/rfc2246.txt 7.4.9
+         * verify_data
+         *   PRF(master_secret, finished_label, MD5(handshake_messages) +
+         *   SHA-1(handshake_messages)) [0..11];
+         */
+        if ($protoVersion == 31) {
+            $seedHash = md5($handshakeMessages, true) . sha1($handshakeMessages, true);
+        } /*
+         * [TLS 1.2]
+         * 7.4.0 https://tools.ietf.org/html/rfc5246
+         * verify_data
+         * PRF(master_secret, finished_label, Hash(handshake_messages))
+         *    [0..verify_data_length-1];
+        */
+        else { // 1.2
+            $cipherSuite = $core->cipherSuite;
+            $seedHash = hash($cipherSuite->getHashAlogV33(), $handshakeMessages, true);
+        }
+
+        $masterSecret = $core->getMasterSecret();
+
+        $verifyData = $prf->prf(self::PRF_LENGTH, $masterSecret, $finishedLabel, $seedHash);
+
+        return $verifyData;
+    }
+
+    public function encode($data)
+    {
+        $core = $this->core;
+
+        $data = $this->encodeHeader($data);
+
+        /*
+         * https://tools.ietf.org/html/rfc5246#section-7.4.9
+         *
+         * Note that this
+         * representation has the same encoding as with previous versions.
+         * Future cipher suites MAY specify other lengths but such length
+         * MUST be at least 12 bytes.
+         */
+        $this->verifyData = substr($data, 0, $this->length);
+
+        // Get all handshakeMessages excluding this message
+        $handshakeMessages = $core->getHandshakeMessages(1);
+
+        // Get verify data
+        $verifyData = $this->getVerifyData($core->isServer ^ true, $handshakeMessages);
+
+        if ($this->verifyData != $verifyData) {
+            throw new TLSAlertException(Alert::create(Alert::BAD_RECORD_MAC),
+                "Handshake Finished: verifyData mismatched:" . base64_encode($this->verifyData) . "<=>" . base64_encode($verifyData));
+        }
+    }
+
+    public function decode()
+    {
+        $core = $this->core;
+
+        $handshakeMessages = $core->getHandshakeMessages();
+
+        $verifyData = $this->getVerifyData($core->isServer, $handshakeMessages);
+
+        $this->msgType = 20;
+        $this->length = strlen($verifyData);
+        return $this->getBinHeader() . $verifyData;
+    }
+
+    public function debugInfo()
+    {
+        /*
+         * struct {
+         *  opaque verify_data[verify_data_length];
+         *  } Finished;
+         */
+        return "[HandshakeType::Finished]\n"
+            . "Verify Data: " . base64_encode($this->verifyData) . "\n";
+    }
+}

--- a/libs/TLS/PTLS/Handshake/HandshakeAbstract.php
+++ b/libs/TLS/PTLS/Handshake/HandshakeAbstract.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace PTLS\Handshake;
+
+use PTLS\Core;
+use PTLS\ProtocolAbstract;
+use PTLS\Exceptions\TLSAlertException;
+use PTLS\Content\Alert;
+
+abstract class HandshakeAbstract extends ProtocolAbstract
+{
+    protected $msgType;
+    protected $core;
+
+    public function __construct(Core $core)
+    {
+        $this->core = $core;
+    }
+
+    public function encodeHeader($data)
+    {
+        // https://tools.ietf.org/html/rfc5246#section-7.4
+        $this->msgType = $msgType = Core::_unpack('C', $data[0]);
+        $this->length = $length = Core::_unpack('N', $data[1] . $data[2] . $data[3] . 0x00) >> 8;
+
+        $data = substr($data, 4, $length);
+
+        $this->payload = $data;
+
+        if ($this->length != strlen($data)) {
+            throw new TLSAlertException(Alert::create(Alert::ILLEGAL_PARAMETER), "Invalid Handshake payload: " . $this->length);
+        }
+
+        return $data;
+    }
+
+    // @Override
+    public function get($property, $default = null)
+    {
+        if ($property == 'length') {
+            return $this->length + 4;
+        }
+
+        parent::get($property, $default);
+    }
+
+    public function getBinHeader()
+    {
+        // MsgType
+        $header = Core::_pack('C', $this->msgType)
+            // Length
+            . Core::_pack('C', 0x00)
+            . Core::_pack('n', $this->length);
+
+        return $header;
+    }
+
+    public function setMsgType($msgType)
+    {
+        $this->msgType = $msgType;
+    }
+
+    /**
+     * for Client Hello and Server Hello
+     */
+    protected function encodeExtensions($data)
+    {
+        $extensions = [];
+
+        for ($j = 0; $j < strlen($data);) {
+            $extType = Core::_unpack('n', $data[$j] . $data[$j + 1]);
+            $extDataLen = Core::_unpack('n', $data[$j + 2] . $data[$j + 3]);
+
+            if (0 == $extDataLen) {
+                $j += 2 + 2;
+                continue;
+            }
+
+            $extData = substr($data, $j + 4, $extDataLen);
+
+            $j += 2 + 2 + $extDataLen;
+
+            $extensions[] = ['type' => $extType, 'data' => $extData];
+        }
+
+        return $extensions;
+    }
+}

--- a/libs/TLS/PTLS/Handshake/HandshakeFactory.php
+++ b/libs/TLS/PTLS/Handshake/HandshakeFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace PTLS\Handshake;
+
+use PTLS\Core;
+use PTLS\Handshake\HandshakeType;
+use PTLS\Exceptions\TLSAlertException;
+
+abstract class HandshakeFactory
+{
+    public static function getInstance(Core $core, $type)
+    {
+        switch ($type) {
+            case HandshakeType::HELLO_REQUEST:
+                return new HelloRequest($core);
+            case HandshakeType::CLIENT_HELLO:
+                return new ClientHello($core);
+            case HandshakeType::SERVER_HELLO:
+                return new ServerHello($core);
+            case HandshakeType::SERVER_HELLO_DONE:
+                return new ServerHelloDone($core);
+            case HandshakeType::CERTIFICATE:
+                return new Certificate($core);
+            case HandshakeType::CLIENT_KEY_EXCHANGE:
+                return new ClientKeyExchange($core);
+            case HandshakeType::FINISHED:
+                return new Finished($core);
+            case HandshakeType::SERVER_KEY_EXCHANGE:
+                return new ServerKeyExchange($core);
+        }
+
+        throw new TLSAlertException(Alert::create(Alert::UNEXPECTED_MESSAGE), "Unknow Handshake Type: $type");
+    }
+}

--- a/libs/TLS/PTLS/Handshake/HandshakeType.php
+++ b/libs/TLS/PTLS/Handshake/HandshakeType.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace PTLS\Handshake;
+
+/**
+ *      enum {
+ *          hello_request(0), client_hello(1), server_hello(2),
+ *          certificate(11), server_key_exchange (12),
+ *          certificate_request(13), server_hello_done(14),
+ *          certificate_verify(15), client_key_exchange(16),
+ *          finished(20), (255)
+ *      } HandshakeType;
+ * struct {
+ *          HandshakeType msg_type;
+ *          uint24 length;
+ *          select (HandshakeType) {
+ *              case hello_request:       HelloRequest;
+ *              case client_hello:        ClientHello;
+ *              case server_hello:        ServerHello;
+ *              case certificate:         Certificate;
+ *              case server_key_exchange: ServerKeyExchange;
+ *              case certificate_request: CertificateRequest;
+ *              case server_hello_done:   ServerHelloDone;
+ *              case certificate_verify:  CertificateVerify;
+ *              case client_key_exchange: ClientKeyExchange;
+ *              case finished:            Finished;
+ *          } body;
+ *      } Handshake;
+ *
+ * NO support for certificate_request(13) and certificate_verify(15)
+ */
+class HandshakeType
+{
+    const HELLO_REQUEST = 0;
+    const CLIENT_HELLO = 1;
+    const SERVER_HELLO = 2;
+    const CERTIFICATE = 11;
+    const SERVER_KEY_EXCHANGE = 12;
+    const SERVER_HELLO_DONE = 14;
+    const CLIENT_KEY_EXCHANGE = 16;
+    const FINISHED = 20;
+}

--- a/libs/TLS/PTLS/Handshake/HelloRequest.php
+++ b/libs/TLS/PTLS/Handshake/HelloRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace PTLS\Handshake;
+
+use PTLS\Core;
+use PTLS\Exceptions\TLSAlertException;
+use PTLS\Content\Alert;
+
+class HelloRequest extends HandshakeAbstract
+{
+    public function __construct(Core $core)
+    {
+        parent::__construct($core);
+    }
+
+    public function encode($data)
+    {
+        $core = $this->core;
+
+        $data = $this->encodeHeader($data);
+
+        if ($core->isServer) {
+            throw new TLSAlertException(Alert::create(Alert::UNEXPECTED_MESSAGE),
+                "Server received Hello Request");
+        } else {
+            // We don't re-negotiate
+            throw new TLSAlertException(Alert::create(Alert::NO_RENEGOTIATION), "No renegotiation");
+        }
+    }
+
+    public function decode()
+    {
+    }
+
+    public function debugInfo()
+    {
+        return "[HandshakeType::HelloRequest]\n";
+    }
+}

--- a/libs/TLS/PTLS/Handshake/ServerHello.php
+++ b/libs/TLS/PTLS/Handshake/ServerHello.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace PTLS\Handshake;
+
+use PTLS\Core;
+use PTLS\CipherSuites;
+use PTLS\Exceptions\TLSAlertException;
+use PTLS\Content\Alert;
+
+class ServerHello extends HandshakeAbstract
+{
+    /**
+     * For Debug
+     */
+    private $requestedExtensions;
+
+    public function __construct(Core $core)
+    {
+        parent::__construct($core);
+    }
+
+    public function encode($data)
+    {
+        $core = $this->core;
+        $connIn = $core->getInDuplex();
+
+        $data = $this->encodeHeader($data);
+
+        $vMajor = Core::_unpack('C', $data[0]);
+        $vMinor = Core::_unpack('C', $data[1]);
+
+        // Server Random
+        $random = substr($data, 2, 32);
+
+        $connIn->random = $random;
+
+        // Session ID
+        $sessionLength = Core::_unpack('C', $data[34]);
+
+        $data = substr($data, 35);
+
+        // SessionID if > 0
+        if ($sessionLength > 0) {
+            $sessionID = substr($data, 35, $sessionLength);
+            $core->setSessionID($sessionID);
+            $data = substr($data, $sessionLength);
+        }
+
+        $cipherID = [Core::_unpack('C', $data[0]), Core::_unpack('C', $data[1])];
+
+        $cipherSuite = new CipherSuites($cipherID);
+
+        if (is_null($cipherSuite)) {
+            throw new TLSAlertException(Alert::create(Alert::INTERNAL_ERROR), "cipherSuite is null");
+        }
+
+        $core->cipherSuite = $cipherSuite;
+
+        // Cipher Suite
+        $core->setCompressionMethod(Core::_unpack('C', $data[2]));
+
+        // Extensions
+        if (strlen($data) < 5) {
+            return;
+        }
+
+        $extLength = Core::_unpack('n', $data[3] . $data[4]);
+        $data = substr($data, 5, $extLength);
+
+        $this->requestedExtensions = $extensions = $this->encodeExtensions($data);
+
+        $core->extensions->onEncodeServerHello($extensions);
+    }
+
+    public function decode()
+    {
+        $core = $this->core;
+
+        $extensions = $core->extensions;
+        $connOut = $core->getOutDuplex();
+        $sessionID = $core->getSessionID();
+
+        list($vMajor, $vMinor) = $core->getVersion();
+
+        // Set server random
+        $connOut->random = Core::getRandom(32);
+
+        $sessionLength = strlen($sessionID);
+
+        $data = Core::_pack('C', $vMajor)
+            . Core::_pack('C', $vMinor)
+            . $connOut->random
+            . Core::_pack('C', $sessionLength);
+
+        if ($sessionLength > 0) {
+            $data .= $sessionID;
+        }
+
+        $cipherSuite = $core->cipherSuite;
+        list($cipher1, $cipher2) = $cipherSuite->getID();
+
+        $data .= Core::_pack('C', $cipher1)
+            . Core::_pack('C', $cipher2);
+
+        // Compression method length
+        $data .= Core::_pack('C', 0x00);
+
+        $extData = $extensions->onDecodeServerHello();
+
+        if (strlen($extData) > 0) {
+            $data .= Core::_pack('n', strlen($extData)) . $extData;
+        }
+
+        $this->msgType = 2;
+        $this->length = strlen($data);
+
+        return $this->getBinHeader() . $data;
+    }
+
+    public function debugInfo()
+    {
+        /*
+         * struct {
+         *    ProtocolVersion server_version;
+         *    Random random;
+         *    SessionID session_id;
+         *    CipherSuite cipher_suite;
+         *    CompressionMethod compression_method;
+         *    select (extensions_present) {
+         *        case false:
+         *            struct {};
+         *        case true:
+         *            Extension extensions<0..2^16-1>;
+         *    };
+         * } ServerHello;
+         */
+        $core = $this->core;
+        $connIn = $this->core->getInDuplex();
+
+        $protoVersion = $core->getProtocolVersion();
+        $sessionID = base64_encode($core->getSessionID());
+        $cipherSuite = $core->cipherSuite->debugInfo();
+
+        $extensions = [];
+
+        // ['type' => $extType, 'data' => $extData]
+        foreach ($this->requestedExtensions as $value) {
+            $extensions[] = "Type: " . dechex($value['type'])
+                . ' Data Length: ' . strlen($value['data']);
+        }
+
+        return "[HandshakeType::ServerHello]\n"
+            . "Lengh:            " . $this->length . "\n"
+            . "Protocol Version: $protoVersion \n"
+            . "Session ID:       $sessionID\n"
+            . "[Extensions]\n"
+            . implode("\n", $extensions) . "\n"
+            . $cipherSuite;
+    }
+}

--- a/libs/TLS/PTLS/Handshake/ServerHelloDone.php
+++ b/libs/TLS/PTLS/Handshake/ServerHelloDone.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace PTLS\Handshake;
+
+use PTLS\Core;
+
+class ServerHelloDone extends HandshakeAbstract
+{
+    public function __construct(Core $core)
+    {
+        parent::__construct($core);
+    }
+
+    public function encode($data)
+    {
+    }
+
+    public function decode()
+    {
+        $this->msgType = 14;
+        $this->length = 0;
+
+        return $this->getBinHeader();
+    }
+
+    public function debugInfo()
+    {
+        return "[HandshakeType::ServerHelloDone]\n";
+    }
+}

--- a/libs/TLS/PTLS/Handshake/ServerKeyExchange.php
+++ b/libs/TLS/PTLS/Handshake/ServerKeyExchange.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace PTLS\Handshake;
+
+use PTLS\Core;
+
+class ServerKeyExchange extends HandshakeAbstract
+{
+    public function __construct(Core $core)
+    {
+        parent::__construct($core);
+    }
+
+    public function encode($data)
+    {
+        $core = $this->core;
+        $extensions = $core->extensions;
+
+        $this->encodeHeader($data);
+
+        if ($core->cipherSuite->isECDHEEnabled()) {
+            $extensions->call('Curve', 'encodeServerKeyExchange', null, $data);
+        }
+    }
+
+    public function decode()
+    {
+        // Extensions\Curve::decodeServerKeyExchange
+    }
+
+    public function debugInfo()
+    {
+        return "[HandshakeType::ServerKeyExchange]\n"
+            . "Lengh: " . $this->length . "\n";
+    }
+}

--- a/libs/TLS/PTLS/LICENSE
+++ b/libs/TLS/PTLS/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Ryohei Nagatsuka
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs/TLS/PTLS/Prf.php
+++ b/libs/TLS/PTLS/Prf.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace PTLS;
+
+use PTLS\TLS;
+
+/**
+ * Pseudorandom Function
+ */
+class Prf
+{
+    private $core;
+
+    public function __construct(Core $core)
+    {
+        $this->core = $core;
+    }
+
+    public function prf($length, $secret, $label, $seed)
+    {
+        $core = $this->core;
+        $protoVersion = $core->getProtocolVersion();
+
+        if ($protoVersion == 31) {
+            return $this->prf31($length, $secret, $label, $seed);
+        } else {
+            return $this->prf32($length, $secret, $label, $seed);
+        }
+    }
+
+    /**
+     * Generate master secret from premaster
+     */
+    public function getMaster($preMaster, $clientRandom, $serverRandom)
+    {
+        $masterSecretLength = 48;
+        $seed = $clientRandom . $serverRandom;
+
+        $masterSecret = $this->prf($masterSecretLength, $preMaster, "master secret", $seed);
+        return $masterSecret;
+    }
+
+
+    /**
+     * Generate secret keys
+     */
+    public function getKeys($masterSecret, $clientRandom, $serverRandom)
+    {
+        $core = $this->core;
+        $cipherSuite = $core->cipherSuite;
+
+        $macLen = $cipherSuite->getMACLen();
+        $keyLen = $cipherSuite->getKeyLen();
+        $ivLen = $cipherSuite->getIVLen();
+
+        $seed = $serverRandom . $clientRandom;
+
+        /*
+         * https://tools.ietf.org/html/rfc5246#section-6.3
+         *
+         * client_write_MAC_key[SecurityParameters.mac_key_length]
+         * server_write_MAC_key[SecurityParameters.mac_key_length]
+         * client_write_key[SecurityParameters.enc_key_length]
+         * server_write_key[SecurityParameters.enc_key_length]
+         * client_write_IV[SecurityParameters.fixed_iv_length]
+         * server_write_IV[SecurityParameters.fixed_iv_length]
+         */
+        $offset = 0;
+        $length = 2 * $macLen + 2 * $keyLen + 2 * $ivLen;
+        $keys = $this->prf($length, $masterSecret, "key expansion", $seed);
+
+        $clientMAC = substr($keys, $offset, $macLen);
+        $offset += $macLen;
+
+        $serverMAC = substr($keys, $offset, $macLen);
+        $offset += $macLen;
+
+        $clientKey = substr($keys, $offset, $keyLen);
+        $offset += $keyLen;
+
+        $serverKey = substr($keys, $offset, $keyLen);
+        $offset += $keyLen;
+
+        $clientIV = substr($keys, $offset, $ivLen);
+        $offset += $ivLen;
+
+        $serverIV = substr($keys, $offset, $ivLen);
+
+        return [
+            'client' => ['MAC' => $clientMAC, 'Key' => $clientKey, 'IV' => $clientIV],
+            'server' => ['MAC' => $serverMAC, 'Key' => $serverKey, 'IV' => $serverIV],
+        ];
+    }
+
+    /**
+     * For TLS1.1
+     */
+    public function prf31($length, $secret, $label, $seed)
+    {
+        $labelAndSeed = $label . $seed;
+
+        $LS1 = substr($secret, 0, ceil(strlen($secret)) / 2);
+        $LS2 = substr($secret, ceil(strlen($secret) / 2));
+
+        $md5 = $this->pHash($length, $LS1, $labelAndSeed, "md5");
+        $sha1 = $this->pHash($length, $LS2, $labelAndSeed, "sha1");
+
+        $result = [];
+        for ($i = 0; $i < strlen($sha1); $i++) {
+            $result[$i] = ($md5[$i]) ^ ($sha1[$i]);
+        }
+
+        return implode("", $result);
+    }
+
+    /**
+     * For TLS1.2
+     */
+    public function prf32($length, $secret, $label, $seed)
+    {
+        $core = $this->core;
+        $cipherSuite = $core->cipherSuite;
+
+        $labelAndSeed = $label . $seed;
+        $hash = $this->pHash($length, $secret, $labelAndSeed, $cipherSuite->getHashAlogV33());
+        return $hash;
+    }
+
+    /**
+     * https://tools.ietf.org/html/rfc5246#section-5
+     *
+     * HMAC and the Pseudorandom Function
+     */
+    public function pHash($length, $secret, $seed, $hashType)
+    {
+        $j = 0;
+
+        $A = hash_hmac($hashType, $seed, $secret, true);
+
+        $result = null;
+        while ($j < $length) {
+            $b = hash_hmac($hashType, $A . $seed, $secret, true);
+
+            $blen = strlen($b);
+
+            if ($j + $blen > $length) {
+                $result .= substr($b, 0, $length - $j);
+            } else {
+                $result .= $b;
+            }
+
+            $A = hash_hmac($hashType, $A, $secret, true);
+
+            $j += $blen;
+        }
+
+        return $result;
+    }
+}

--- a/libs/TLS/PTLS/ProtocolAbstract.php
+++ b/libs/TLS/PTLS/ProtocolAbstract.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace PTLS;
+
+abstract class ProtocolAbstract implements DataConverterInterface
+{
+    protected $length;
+    protected $payload;
+
+    abstract public function debugInfo();
+
+    /**
+     * Get properties
+     */
+    public function get($property, $default = null)
+    {
+        if (property_exists($this, $property)) {
+            return $this->$property;
+        }
+
+        return $default;
+    }
+
+    /**
+     * Set properties
+     */
+    public function set($property, $value)
+    {
+        $this->$property = $value;
+        return $this;
+    }
+}

--- a/libs/TLS/PTLS/Record/AEADCipherRecord.php
+++ b/libs/TLS/PTLS/Record/AEADCipherRecord.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace PTLS\Record;
+
+use PTLS\Core;
+use PTLS\ContentType;
+use PTLS\ConnectionDuplex;
+use PTLS\Exceptions\TLSAlertException;
+use PTLS\Content\Alert;
+
+/**
+ * https://tools.ietf.org/html/rfc5246#section-6.2.3.3
+ *
+ *    struct {
+ *       opaque nonce_explicit[SecurityParameters.record_iv_length];
+ *       aead-ciphered struct {
+ *           opaque content[TLSCompressed.length];
+ *       };
+ *    } GenericAEADCipher;
+ *
+ * Supporting GCM
+ */
+class AEADCipherRecord extends CipherRecordAbstract
+{
+    const nonceExplicitLen = 8;
+
+    public function __construct(ConnectionDuplex $conn)
+    {
+        parent::__construct($conn);
+    }
+
+    /**
+     * @Override
+     */
+    protected function encodeContent()
+    {
+        $payload = $this->payload;
+
+        $conn = $this->conn;
+        $core = $conn->getCore();
+
+        $cipherSuite = $core->cipherSuite;
+        $sharedKey = $conn->Key;
+
+        $nonceImplicit = $conn->IV;
+
+        // 16 => tag length
+        $gcmHeaderLen = self::nonceExplicitLen + 16;
+        $rawPayloadLen = strlen($this->payload);
+
+        if ($rawPayloadLen < $gcmHeaderLen) {
+            throw new TLSAlertException(Alert::create(Alert::BAD_RECORD_MAC), "GCM payload too short");
+        }
+
+        $nonceExplicit = substr($this->payload, 0, self::nonceExplicitLen);
+
+        $aad = $this->getAAD($rawPayloadLen - $gcmHeaderLen);
+
+        // Copy payload over to encPayload
+        $this->encPayload = $this->payload;
+        $this->encLength = $this->length;
+
+        $nonce = $nonceImplicit . $nonceExplicit;
+        $encData = substr($this->encPayload, self::nonceExplicitLen);
+
+        $data = $cipherSuite->gcmDecrypt($encData, $sharedKey, $nonce, $aad);
+
+        // If the decryption fails, a fatal bad_record_mac alert MUST be generated
+        if (false === $data) {
+            throw new TLSAlertException(Alert::create(Alert::BAD_RECORD_MAC), "Cipher gcm decryption failed");
+        }
+
+        // Re-set the length
+        $this->length = strlen($data);
+
+        // Set Payload
+        $this->payload = $payload = substr($data, 0, $this->length);
+
+        $this->incrementSeq();
+
+        $content = $core->content;
+
+        $content->encodeContent($this->contentType, $this->payload, $this);
+    }
+
+    /**
+     * @Override
+     */
+    public function decode()
+    {
+        $conn = $this->conn;
+        $core = $conn->getCore();
+
+        $cipherSuite = $core->cipherSuite;
+
+        $nonceImplicit = $conn->IV; // 4 bytes
+        $sharedKey = $conn->Key;
+
+        $aad = $this->getAAD($this->length);
+
+        $nonceExplicit = $this->getSeq(); // 8 bytes
+
+        /*
+         *  https://tools.ietf.org/html/rfc5288 page 2
+         *
+         *  struct {
+         *       opaque salt[4];
+         *       opaque nonce_explicit[8];
+         *  } GCMNonce;
+         */
+        $nonce = $nonceImplicit . $nonceExplicit;
+
+        $encData = $cipherSuite->gcmEncrypt($this->payload, $sharedKey, $nonce, $aad);
+
+        if (false === $encData) {
+            throw new TLSAlertException(Alert::create(Alert::BAD_RECORD_MAC), "Cipher gcm encryption failed");
+        }
+
+        $this->incrementSeq();
+
+        if ($this->contentType == ContentType::HANDSHAKE) {
+            $core->countHandshakeMessages($this->payload);
+        }
+
+        $payload = $nonceExplicit . $encData;
+
+        $this->set('payload', $payload);
+
+        return parent::decode();
+    }
+
+    /**
+     * Additional Authentication Data
+     */
+    public function getAAD($length)
+    {
+        $conn = $this->conn;
+        $core = $conn->getCore();
+        $cipherSuite = $core->cipherSuite;
+
+        list($vMajor, $vMinor) = $core->getVersion();
+
+        if (is_null($this->seq)) {
+            $this->seq = self::getZeroSeq();
+        }
+
+        $contentType = Core::_pack('C', $this->contentType);
+        $major = Core::_pack('C', $vMajor);
+        $minor = Core::_pack('C', $vMinor);
+
+        $length = Core::_pack('n', $length);
+
+        /*
+         * https://tools.ietf.org/html/rfc5246#section-6.2.3.3
+         *
+         *  additional_data = seq_num + TLSCompressed.type +
+         *               TLSCompressed.version + TLSCompressed.length;
+         *
+         */
+        $concat = implode('', $this->seq)
+            . $contentType
+            . $major
+            . $minor
+            . $length;
+
+        return $concat;
+    }
+}

--- a/libs/TLS/PTLS/Record/BlockCipherRecord.php
+++ b/libs/TLS/PTLS/Record/BlockCipherRecord.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace PTLS\Record;
+
+use PTLS\Core;
+use PTLS\ContentType;
+use PTLS\ConnectionDuplex;
+use PTLS\Exceptions\TLSAlertException;
+use PTLS\Content\Alert;
+
+/**
+ * https://tools.ietf.org/html/rfc5246#section-6.2.3.2
+ *  struct {
+ *       opaque IV[SecurityParameters.record_iv_length];
+ *      block-ciphered struct {
+ *          opaque content[TLSCompressed.length];
+ *          opaque MAC[SecurityParameters.mac_length];
+ *          uint8 padding[GenericBlockCipher.padding_length];
+ *          uint8 padding_length;
+ *      };
+ *  } GenericBlockCipher;
+ */
+class BlockCipherRecord extends Record
+{
+    const MAX_CIPHER_LENGTH = 18432; // 2^14 + 2048
+
+    private $seq;
+    private $encPayload;
+    private $encLength;
+
+    public function __construct(ConnectionDuplex $conn)
+    {
+        parent::__construct($conn);
+        $this->maxLength = self::MAX_CIPHER_LENGTH;
+    }
+
+    /**
+     * @Override
+     */
+    public function get($property, $default = null)
+    {
+        if ($property == 'length') {
+            return 5 + $this->encLength;
+        }
+
+        return parent::get($property);
+    }
+
+    /**
+     * @Override
+     */
+    protected function encodeContent()
+    {
+        $payload = $this->payload;
+
+        $conn = $this->conn;
+        $core = $conn->getCore();
+
+        $cipherSuite = $core->cipherSuite;
+
+        $sharedKey = $conn->Key;
+        $ivLen = $cipherSuite->getIVLen();
+        $macLen = $cipherSuite->getMACLen();
+
+        // Copy payload over to encPayload
+        $this->encPayload = $this->payload;
+        $this->encLength = $this->length;
+
+        $IV = substr($this->encPayload, 0, $ivLen);
+
+        $data = $cipherSuite->blockDecrypt($this->encPayload, $sharedKey, $IV);
+
+        // If the decryption fails, a fatal bad_record_mac alert MUST be generated
+        if (false === $data) {
+            throw new TLSAlertException(Alert::create(Alert::BAD_RECORD_MAC), "Cipher block decryption failed");
+        }
+
+        // padding length - https://tools.ietf.org/html/rfc5246#section-6.2.3.2
+        $paddingLength = Core::_unpack('C', $data[strlen($data) - 1]);
+
+        // Re-set the length
+        $this->length = strlen($data) - $ivLen - $macLen - $paddingLength - 1;
+
+        // Set Payload
+        $this->payload = $payload = substr($data, $ivLen, $this->length);
+
+        if (strlen($this->payload) != $this->length) {
+            throw new TLSAlertException(Alert::create(Alert::BAD_RECORD_MAC), "Invalid block cipher length");
+        }
+
+        // MAC to verify
+        $MAC = substr($data, $ivLen + $this->length, $macLen);
+        $MAC2 = $this->calculateMAC();
+
+        if ($MAC != $MAC2) {
+            throw new TLSAlertException(Alert::create(Alert::BAD_RECORD_MAC),
+                "Mismatch MAC Record " . base64_encode($MAC) . "<=>" . base64_encode($MAC2));
+        }
+
+        $this->incrementSeq();
+
+        $content = $core->content;
+
+        $content->encodeContent($this->contentType, $this->payload, $this);
+    }
+
+    /**
+     * @Override
+     */
+    public function decode()
+    {
+        $conn = $this->conn;
+        $core = $conn->getCore();
+
+        $cipherSuite = $core->cipherSuite;
+
+        $sharedKey = $conn->Key;
+        $ivLen = $cipherSuite->getIVLen();
+        $macLen = $cipherSuite->getMACLen();
+
+        $MAC = $this->calculateMAC();
+
+        $IV = Core::getRandom($ivLen);
+
+        $data = $this->payload . $MAC;
+
+        // Calculate and append padding
+        $fpd = function ($l, $bz) {
+            return (($l + $bz) - ($l % $bz)) - $l;
+        };
+
+        $paddingLength = $fpd(strlen($this->payload . $MAC) + 1, $ivLen);
+
+        $data .= Core::_pack('C', $paddingLength);
+
+        $encData = $cipherSuite->blockEncrypt($data, $sharedKey, $IV);
+
+        if (false === $encData) {
+            throw new TLSAlertException(Alert::create(Alert::BAD_RECORD_MAC), "Cipher block encryption failed");
+        }
+
+        $encData = $IV . $encData;
+
+        $this->incrementSeq();
+
+        if ($this->contentType == ContentType::HANDSHAKE) {
+            $core->countHandshakeMessages($this->payload);
+        }
+
+        $this->set('payload', $encData);
+
+        return parent::decode();
+    }
+
+    private function incrementSeq()
+    {
+        if (is_null($this->seq)) {
+            $this->seq = $this->getZeroSeq();
+        }
+
+        for ($i = 7; $i >= 0; $i--) {
+            $num = Core::_unpack('C', $this->seq[$i]) + 1;
+            $this->seq[$i] = Core::_pack('C', $num);
+
+            if ($num % 256 > 0) {
+                break;
+            }
+        }
+    }
+
+    private static function getZeroSeq()
+    {
+        $seq = [];
+        for ($i = 0; $i < 8; $i++) {
+            $seq[$i] = Core::_pack('C', 0);
+        }
+
+        return $seq;
+    }
+
+    public function calculateMAC()
+    {
+        $conn = $this->conn;
+        $core = $conn->getCore();
+        $cipherSuite = $core->cipherSuite;
+
+        list($vMajor, $vMinor) = $core->getVersion();
+
+        if (is_null($this->seq)) {
+            $this->seq = self::getZeroSeq();
+        }
+
+        $secretMAC = $conn->MAC;
+
+        $contentType = Core::_pack('C', $this->contentType);
+        $major = Core::_pack('C', $vMajor);
+        $minor = Core::_pack('C', $vMinor);
+
+        $length = Core::_pack('n', strlen($this->payload));
+
+        /*
+         * https://tools.ietf.org/html/rfc5246#section-6.2.3.1
+         *
+         * The MAC is generated as:
+         *
+         * MAC(MAC_write_key, seq_num +
+         *                    TLSCompressed.type +
+         *                    TLSCompressed.version +
+         *                    TLSCompressed.length +
+         *                    TLSCompressed.fragment);
+         */
+        $concat = implode('', $this->seq)
+            . $contentType
+            . $major
+            . $minor
+            . $length
+            . $this->payload;
+
+        //$macStr = $cipherSuite->hashHmac($concat, $secretMAC, false );
+        $mac = $cipherSuite->hashHmac($concat, $secretMAC);
+
+        return $mac;
+    }
+}

--- a/libs/TLS/PTLS/Record/CipherRecordAbstract.php
+++ b/libs/TLS/PTLS/Record/CipherRecordAbstract.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace PTLS\Record;
+
+use PTLS\Core;
+use PTLS\ContentType;
+use PTLS\ConnectionDuplex;
+use PTLS\Exceptions\TLSAlertException;
+use PTLS\Content\Alert;
+
+abstract class CipherRecordAbstract extends Record
+{
+    const MAX_CIPHER_LENGTH = 18432; // 2^14 + 2048
+
+    protected $seq;
+    protected $encPayload;
+    protected $encLength;
+
+    public function __construct(ConnectionDuplex $conn)
+    {
+        parent::__construct($conn);
+        $this->maxLength = self::MAX_CIPHER_LENGTH;
+    }
+
+    /**
+     * @Override
+     */
+    public function get($property, $default = null)
+    {
+        if ($property == 'length') {
+            return 5 + $this->encLength;
+        }
+
+        return parent::get($property);
+    }
+
+    protected function getSeq()
+    {
+        if (is_null($this->seq)) {
+            $this->seq = self::getZeroSeq();
+        }
+
+        return implode('', $this->seq);
+    }
+
+    protected function incrementSeq()
+    {
+        if (is_null($this->seq)) {
+            $this->seq = $this->getZeroSeq();
+        }
+
+        for ($i = 7; $i >= 0; $i--) {
+            $num = Core::_unpack('C', $this->seq[$i]) + 1;
+            $this->seq[$i] = Core::_pack('C', $num);
+
+            if ($num % 256 > 0) {
+                break;
+            }
+        }
+    }
+
+    protected static function getZeroSeq()
+    {
+        $seq = [];
+        for ($i = 0; $i < 8; $i++) {
+            $seq[$i] = Core::_pack('C', 0);
+        }
+
+        return $seq;
+    }
+}

--- a/libs/TLS/PTLS/Record/Record.php
+++ b/libs/TLS/PTLS/Record/Record.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace PTLS\Record;
+
+use PTLS\Core;
+use PTLS\ContentType;
+use PTLS\ProtocolAbstract;
+use PTLS\ConnectionDuplex;
+use PTLS\Buffer;
+use PTLS\Exceptions\TLSAlertException;
+use PTLS\Content\Alert;
+
+/**
+ * https://tools.ietf.org/html/rfc5246#section-6.2.1
+ */
+class Record extends ProtocolAbstract
+{
+    const MAX_LENGTH = 17408; // 2^14 + 1024
+    const MAX_BUFFER_LENGTH = 34816; // 17408 * 2
+
+    public $contentType;
+
+    protected $conn;
+    protected $dataRest;
+    protected $maxLength;
+
+    private $encodeBuffer;
+
+    public function __construct(ConnectionDuplex $conn)
+    {
+        $this->conn = $conn;
+        $this->encodeBuffer = new Buffer();
+        $this->maxLength = self::MAX_LENGTH;
+    }
+
+    public function getCore()
+    {
+        return $this->conn->getCore();
+    }
+
+    public function getConn()
+    {
+        return $this->conn;
+    }
+
+    /**
+     * Delegation to ConnectionDuplex::cipherChanged()
+     */
+    public function cipherChanged()
+    {
+        return $this->conn->cipherChanged();
+    }
+
+    protected function encodeHeader($data)
+    {
+        $data = $this->encodeBuffer->flush() . $data;
+
+        $this->contentType = Core::_unpack('C', $data[0]);
+
+        $vMajor = Core::_unpack('C', $data[1]);
+        $vMinor = Core::_unpack('C', $data[2]);
+
+        $this->length = Core::_unpack('n', $data[3] . $data[4]);
+
+        if ($this->length > $this->maxLength) {//|| strlen($data) > self::MAX_BUFFER_LENGTH )
+            /*
+             * A TLSCiphertext record was received that had a length more than
+             * 2^14+2048 bytes, or a record decrypted to a TLSCompressed record
+             * with more than 2^14+1024 bytes.
+             */
+            throw new TLSAlertException(Alert::create(Alert::RECORD_OVERFLOW), "Exceed max length of payload: " . strlen($data));
+        }
+
+        if ($this->length > strlen($data)) {
+            $this->encodeBuffer->set($data);
+            return false;
+        }
+
+        $this->payload = substr($data, 5, $this->length);
+        $this->dataRest = substr($data, 5 + $this->length);
+
+        return true;
+    }
+
+    protected function encodeContent()
+    {
+        $core = $this->getCore();
+        $content = $core->content;
+
+        $content->encodeContent($this->contentType, $this->payload, $this);
+    }
+
+    public function encode($data)
+    {
+        $this->reset();
+
+        if (!$this->encodeHeader($data)) {
+            return;
+        }
+
+        $this->encodeContent();
+    }
+
+    /**
+     * @Override
+     */
+    public function get($property, $default = null)
+    {
+        if ($property == 'length') {
+            return 5 + $this->length;
+        }
+
+        return parent::get($property);
+    }
+
+    /**
+     * @Override
+     */
+    public function set($property, $value)
+    {
+        parent::set($property, $value);
+
+        if ($property == 'payload') {
+            $this->length = strlen($this->payload);
+        }
+
+        return $this;
+    }
+
+    public function reset()
+    {
+        $this->contentType =
+        $this->dataRest =
+        $this->payload = null;
+
+        $this->length = -1;
+    }
+
+    public function decode()
+    {
+        $core = $this->getCore();
+
+        list($vMajor, $vMinor) = $core->getVersion();
+
+        // type
+        $data = Core::_pack('C', $this->contentType)
+            . Core::_pack('C', $vMajor)
+            . Core::_pack('C', $vMinor)
+            . Core::_pack('n', $this->length)
+            . $this->payload;
+
+        // Handshake
+        if ($this->contentType == ContentType::HANDSHAKE && !$this->conn->isCipherChanged) {
+            $core->countHandshakeMessages($this->payload);
+        }
+
+        $this->reset();
+
+        return $data;
+    }
+
+    public function debugInfo()
+    {
+        $core = $this->getCore();
+
+        $outputs[] = "ContentType:      " . ContentType::getString($this->contentType);
+        $outputs[] = "Length:           " . $this->length;
+        $outputs[] = "Received Payload: " . strlen($this->payload);
+
+        $r = "[Record Protocol]\n" . implode("\n", $outputs) . "\n"
+            . "[Content]\n" . $core->content->debugInfo();
+
+        return $r;
+    }
+}

--- a/libs/TLS/PTLS/TLS.php
+++ b/libs/TLS/PTLS/TLS.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace PTLS;
+
+use PTLS\Exceptions\TLSAlertException;
+use PTLS\Exceptions\TLSException;
+
+class TLS implements DataConverterInterface
+{
+    private $core;
+    private $bufferOut;
+
+    public function __construct($isServer, Config $config)
+    {
+        $this->core = new Core($isServer, $config);
+        $this->bufferOut = new Buffer();
+    }
+
+    public function isHandshaked()
+    {
+        return $this->core->isHandshaked;
+    }
+
+    public function isClosed()
+    {
+        return $this->core->isClosed;
+    }
+
+    public function input()
+    {
+        $core = $this->core;
+        return $core->getBufferIn()->flush();
+    }
+
+    public function encode($data)
+    {
+        $core = $this->core;
+
+        $in = $core->getInDuplex();
+
+        try {
+            $in->encodeRecord($data);
+        } catch (TLSAlertException $e) {
+            // Set output if any
+            $e->setOutput($core);
+
+            // Re-throw so that the upper layer can catch it
+            throw $e;
+        }
+    }
+
+    public function decode()
+    {
+        $core = $this->core;
+        $coreBufferOut = $core->getBufferOut();
+
+        $out = '';
+
+        if ($coreBufferOut->length() > 0) {
+            $out = $coreBufferOut->flush();
+        }
+
+        if (!$core->isHandshaked) {
+            return $out;
+        }
+
+        $payload = $this->bufferOut->flush();
+
+        if (0 >= strlen($payload)) {
+            return $out;
+        }
+
+        $connOut = $core->getOutDuplex();
+
+        $out .= $connOut->decodeRecord($payload);
+
+        return $out;
+    }
+
+    public function output($data, $isAppend = false)
+    {
+        $core = $this->core;
+        $bufferOut = $this->bufferOut;
+
+        if (!$core->isHandshaked) {
+            throw new TLSException('Handshake is not done');
+        }
+
+        if ($isAppend) {
+            $bufferOut->append($data);
+        } else {
+            $bufferOut->set($data);
+        }
+
+        return $this;
+    }
+
+    public function append($data)
+    {
+        return $this->setOutput($data, true);
+    }
+
+    public function getDebug()
+    {
+        return new Debug($this->core);
+    }
+}

--- a/libs/TLS/PTLS/TLSContext.php
+++ b/libs/TLS/PTLS/TLSContext.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace PTLS;
+
+class TLSContext
+{
+    public static function getServerConfig(array $arrConfig)
+    {
+        return new Config(Config::SERVER, $arrConfig);
+    }
+
+    public static function getClientConfig(array $arrConfig)
+    {
+        return new Config(Config::CLIENT, $arrConfig);
+    }
+
+    public static function createTLS(Config $config)
+    {
+        return new TLS($config->isServer(), $config);
+    }
+}

--- a/libs/TLS/PTLS/X509.php
+++ b/libs/TLS/PTLS/X509.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace PTLS;
+
+use PTLS\Exceptions\TLSException;
+
+class X509
+{
+    public static $pemCrtBegin = '-----BEGIN CERTIFICATE-----';
+    public static $pemCrtEnd = '-----END CERTIFICATE-----';
+
+    public static function crtDerToPem($der)
+    {
+        $pem = self::$pemCrtBegin . "\n"
+            . chunk_split(base64_encode($der), 64)
+            . self::$pemCrtEnd;
+
+        return $pem;
+    }
+
+    public static function verifyCrt($der)
+    {
+        $pem = self::crtDerToPem($der);
+        $crt = openssl_x509_parse($pem);
+
+        return is_array($crt) ? true : false;
+    }
+
+    public static function crtPemToDer($pems)
+    {
+        $arrPems = explode(self::$pemCrtBegin, $pems);
+        $arrPems = array_splice($arrPems, 1);
+
+        $crtDers = [];
+
+        foreach ($arrPems as $pem) {
+            $pem = str_replace(self::$pemCrtEnd, '', $pem);
+            $der = base64_decode(str_replace("\n", '', $pem));
+
+            if (!self::verifyCrt($der)) {
+                throw new TLSException("Invalid Certificate");
+            }
+
+            $crtDers[] = $der;
+        }
+
+        return $crtDers;
+    }
+
+    /**
+     *  Get the pem file, and convert to der
+     */
+    public static function crtFilePemToDer(array $files)
+    {
+        if (!count($files)) {
+            throw new TLSException("No certificate files");
+        }
+
+        $pem = '';
+
+        foreach ($files as $file) {
+            $pem .= file_get_contents($file);
+        }
+
+        return self::crtPemToDer($pem);
+    }
+
+    public static function getPrivateKey($file, $passCode = "")
+    {
+        $privateKey = file_get_contents($file);
+        return openssl_get_privatekey($privateKey, $passCode);
+    }
+
+
+    public static function getPublicKey(array $crtDers)
+    {
+        $pem = X509::crtDerToPem($crtDers[0]);
+        $publicKey = openssl_pkey_get_public($pem);
+
+        return $publicKey;
+    }
+}

--- a/libs/TLS/autoloader.php
+++ b/libs/TLS/autoloader.php
@@ -1,0 +1,36 @@
+<?php
+
+$autoloader = new AutoloaderTLS('PTLS');
+$autoloader->register();
+
+class AutoloaderTLS
+{
+    private $namespace;
+
+    public function __construct($namespace = null)
+    {
+        $this->namespace = $namespace;
+    }
+
+    public function register()
+    {
+        spl_autoload_register([$this, 'loadClass']);
+    }
+
+    public function loadClass($className)
+    {
+        $file = __DIR__ . DIRECTORY_SEPARATOR . str_replace('\\', DIRECTORY_SEPARATOR, $className) . '.php';
+        if (file_exists($file)) {
+            require_once $file;
+        }
+    }
+}
+
+class TLSState
+{
+    const Init = 0;
+    const Connecting = 1;
+    const Connected = 2;
+    const TLSisSend = 3;
+    const TLSisReceived = 4;
+}

--- a/libs/helpers/Module.php
+++ b/libs/helpers/Module.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * IPS Constants Loader
+ */
+require_once(__DIR__ . '/ips.constants.php');
+
+class Module extends IPSModule
+{
+    use ModuleHelper;
+
+    protected $force_ident = false;
+
+    /**
+     * create instance
+     * @return bool|void
+     */
+    public function Create()
+    {
+        parent::Create();
+
+        // register global properties
+        $this->RegisterPropertyBoolean('log', true);
+
+        // register kernel messages
+        $this->RegisterMessage(0, IPS_KERNELMESSAGE);
+    }
+
+    /**
+     * destroy instance
+     * @return bool|void
+     */
+    public function Destroy()
+    {
+        parent::Destroy();
+
+        // remove instance profiles
+        $profiles = IPS_GetVariableProfileList();
+        foreach ($profiles AS $profile) {
+            if (strstr($profile, $this->prefix . '.' . $this->InstanceID)) {
+                IPS_DeleteVariableProfile($profile);
+            }
+        }
+    }
+
+    /**
+     * Enable Action
+     * attach prefix to ident
+     * @param string $Ident
+     * @return bool
+     */
+    protected function EnableAction($Ident)
+    {
+        $Ident = $this->force_ident ? $Ident : $this->identifier($Ident);
+        $this->force_ident = false;
+
+        return parent::EnableAction($Ident);
+    }
+
+    /**
+     * Enable Action
+     * attach prefix to ident
+     * @param string $Ident
+     * @return bool
+     */
+    protected function DisableAction($Ident)
+    {
+        $Ident = $this->force_ident ? $Ident : $this->identifier($Ident);
+        $this->force_ident = false;
+
+        return parent::DisableAction($Ident);
+    }
+}

--- a/libs/helpers/Readme.md
+++ b/libs/helpers/Readme.md
@@ -1,0 +1,2 @@
+# IP-Symcon Helper Classes
+![IP-Symcon 5.x](https://img.shields.io/badge/IP--Symcon-5.x-blue.svg)

--- a/libs/helpers/Traits/BufferHelper.php
+++ b/libs/helpers/Traits/BufferHelper.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Trait to read / write object properties in instance buffer
+ */
+trait BufferHelper
+{
+    /**
+     * get property
+     * @param string $name property name
+     * @return mixed $value property value
+     */
+    public function __get($name)
+    {
+        if (strpos($name, 'Multi_') === 0 && is_array($this->{'BufferList_' . $name})) {
+            $Lines = "";
+            foreach ($this->{'BufferList_' . $name} as $BufferIndex) {
+                $Lines .= $this->{'Part_' . $name . $BufferIndex};
+            }
+            return unserialize($Lines);
+        }
+        return unserialize($this->GetBuffer($name));
+    }
+
+    /**
+     * write property
+     * @param string $name property name
+     * @param mixed $value property value
+     */
+    public function __set($name, $value)
+    {
+        $Data = serialize($value);
+        if (strpos($name, 'Multi_') === 0) {
+            $OldBuffers = $this->{'BufferList_' . $name};
+            if ($OldBuffers == false) {
+                $OldBuffers = [];
+            }
+            $Lines = str_split($Data, 8000);
+            foreach ($Lines as $BufferIndex => $BufferLine) {
+                $this->{'Part_' . $name . $BufferIndex} = $BufferLine;
+            }
+            $NewBuffers = array_keys($Lines);
+            $this->{'BufferList_' . $name} = $NewBuffers;
+            $DelBuffers = array_diff_key($OldBuffers, $NewBuffers);
+            foreach ($DelBuffers as $DelBuffer) {
+                $this->{'Part_' . $name . $DelBuffer} = "";
+            }
+            return;
+        }
+
+        $this->SetBuffer($name, $Data);
+    }
+}

--- a/libs/helpers/Traits/SymconHelper.php
+++ b/libs/helpers/Traits/SymconHelper.php
@@ -1,0 +1,174 @@
+<?php
+
+/**
+ * Helper class to provide system-wide constants below IP-Symcon 5.0
+ */
+class SymconHelper
+{
+    public static function loadConstants()
+    {
+        if (@constant('IPS_BASE') == null) {
+            // --- BASE MESSAGE
+            define('IPS_BASE', 10000);                             // Base Message
+            define('IPS_KERNELSHUTDOWN', IPS_BASE + 1);            // Pre Shutdown Message, Runlevel UNINIT Follows
+            define('IPS_KERNELSTARTED', IPS_BASE + 2);             // Post Ready Message
+
+            // --- KERNEL
+            define('IPS_KERNELMESSAGE', IPS_BASE + 100);           // Kernel Message
+            define('KR_CREATE', IPS_KERNELMESSAGE + 1);            // Kernel is beeing created
+            define('KR_INIT', IPS_KERNELMESSAGE + 2);              // Kernel Components are beeing initialised, Modules loaded, Settings read
+            define('KR_READY', IPS_KERNELMESSAGE + 3);             // Kernel is ready and running
+            define('KR_UNINIT', IPS_KERNELMESSAGE + 4);            // Got Shutdown Message, unloading all stuff
+            define('KR_SHUTDOWN', IPS_KERNELMESSAGE + 5);          // Uninit Complete, Destroying Kernel Inteface
+
+            // --- KERNEL LOGMESSAGE
+            define('IPS_LOGMESSAGE', IPS_BASE + 200);              // Logmessage Message
+            define('KL_MESSAGE', IPS_LOGMESSAGE + 1);              // Normal Message                      | FG: Black | BG: White  | STLYE : NONE
+            define('KL_SUCCESS', IPS_LOGMESSAGE + 2);              // Success Message                     | FG: Black | BG: Green  | STYLE : NONE
+            define('KL_NOTIFY', IPS_LOGMESSAGE + 3);               // Notiy about Changes                 | FG: Black | BG: Blue   | STLYE : NONE
+            define('KL_WARNING', IPS_LOGMESSAGE + 4);              // Warnings                            | FG: Black | BG: Yellow | STLYE : NONE
+            define('KL_ERROR', IPS_LOGMESSAGE + 5);                // Error Message                       | FG: Black | BG: Red    | STLYE : BOLD
+            define('KL_DEBUG', IPS_LOGMESSAGE + 6);                // Debug Informations + Script Results | FG: Grey  | BG: White  | STLYE : NONE
+            define('KL_CUSTOM', IPS_LOGMESSAGE + 7);               // User Message                        | FG: Black | BG: White  | STLYE : NONE
+
+            // --- MODULE LOADER
+            define('IPS_MODULEMESSAGE', IPS_BASE + 300);           // ModuleLoader Message
+            define('ML_LOAD', IPS_MODULEMESSAGE + 1);              // Module loaded
+            define('ML_UNLOAD', IPS_MODULEMESSAGE + 2);            // Module unloaded
+
+            // --- OBJECT MANAGER
+            define('IPS_OBJECTMESSAGE', IPS_BASE + 400);
+            define('OM_REGISTER', IPS_OBJECTMESSAGE + 1);          // Object was registered
+            define('OM_UNREGISTER', IPS_OBJECTMESSAGE + 2);        // Object was unregistered
+            define('OM_CHANGEPARENT', IPS_OBJECTMESSAGE + 3);      // Parent was Changed
+            define('OM_CHANGENAME', IPS_OBJECTMESSAGE + 4);        // Name was Changed
+            define('OM_CHANGEINFO', IPS_OBJECTMESSAGE + 5);        // Info was Changed
+            define('OM_CHANGETYPE', IPS_OBJECTMESSAGE + 6);        // Type was Changed
+            define('OM_CHANGESUMMARY', IPS_OBJECTMESSAGE + 7);     // Summary was Changed
+            define('OM_CHANGEPOSITION', IPS_OBJECTMESSAGE + 8);    // Position was Changed
+            define('OM_CHANGEREADONLY', IPS_OBJECTMESSAGE + 9);    // ReadOnly was Changed
+            define('OM_CHANGEHIDDEN', IPS_OBJECTMESSAGE + 10);     // Hidden was Changed
+            define('OM_CHANGEICON', IPS_OBJECTMESSAGE + 11);       // Icon was Changed
+            define('OM_CHILDADDED', IPS_OBJECTMESSAGE + 12);       // Child for Object was added
+            define('OM_CHILDREMOVED', IPS_OBJECTMESSAGE + 13);     // Child for Object was removed
+            define('OM_CHANGEIDENT', IPS_OBJECTMESSAGE + 14);      // Ident was Changed
+            define('OM_CHANGEDISABLED', IPS_OBJECTMESSAGE + 15);   // Operability has changed
+
+            // --- INSTANCE MANAGER
+            define('IPS_INSTANCEMESSAGE', IPS_BASE + 500);         // Instance Manager Message
+            define('IM_CREATE', IPS_INSTANCEMESSAGE + 1);          // Instance created
+            define('IM_DELETE', IPS_INSTANCEMESSAGE + 2);          // Instance deleted
+            define('IM_CONNECT', IPS_INSTANCEMESSAGE + 3);         // Instance connectged
+            define('IM_DISCONNECT', IPS_INSTANCEMESSAGE + 4);      // Instance disconncted
+            define('IM_CHANGESTATUS', IPS_INSTANCEMESSAGE + 5);    // Status was Changed
+            define('IM_CHANGESETTINGS', IPS_INSTANCEMESSAGE + 6);  // Settings were Changed
+            define('IM_CHANGESEARCH', IPS_INSTANCEMESSAGE + 7);    // Searching was started/stopped
+            define('IM_SEARCHUPDATE', IPS_INSTANCEMESSAGE + 8);    // Searching found new results
+            define('IM_SEARCHPROGRESS', IPS_INSTANCEMESSAGE + 9);  // Searching progress in %
+            define('IM_SEARCHCOMPLETE', IPS_INSTANCEMESSAGE + 10); // Searching is complete
+
+            // --- VARIABLE MANAGER
+            define('IPS_VARIABLEMESSAGE', IPS_BASE + 600);              // Variable Manager Message
+            define('VM_CREATE', IPS_VARIABLEMESSAGE + 1);               // Variable Created
+            define('VM_DELETE', IPS_VARIABLEMESSAGE + 2);               // Variable Deleted
+            define('VM_UPDATE', IPS_VARIABLEMESSAGE + 3);               // On Variable Update
+            define('VM_CHANGEPROFILENAME', IPS_VARIABLEMESSAGE + 4);    // On Profile Name Change
+            define('VM_CHANGEPROFILEACTION', IPS_VARIABLEMESSAGE + 5);  // On Profile Action Change
+
+            // --- SCRIPT MANAGER
+            define('IPS_SCRIPTMESSAGE', IPS_BASE + 700);           // Script Manager Message
+            define('SM_CREATE', IPS_SCRIPTMESSAGE + 1);            // On Script Create
+            define('SM_DELETE', IPS_SCRIPTMESSAGE + 2);            // On Script Delete
+            define('SM_CHANGEFILE', IPS_SCRIPTMESSAGE + 3);        // On Script File changed
+            define('SM_BROKEN', IPS_SCRIPTMESSAGE + 4);            // Script Broken Status changed
+
+            // --- EVENT MANAGER
+            define('IPS_EVENTMESSAGE', IPS_BASE + 800);             // Event Scripter Message
+            define('EM_CREATE', IPS_EVENTMESSAGE + 1);             // On Event Create
+            define('EM_DELETE', IPS_EVENTMESSAGE + 2);             // On Event Delete
+            define('EM_UPDATE', IPS_EVENTMESSAGE + 3);
+            define('EM_CHANGEACTIVE', IPS_EVENTMESSAGE + 4);
+            define('EM_CHANGELIMIT', IPS_EVENTMESSAGE + 5);
+            define('EM_CHANGESCRIPT', IPS_EVENTMESSAGE + 6);
+            define('EM_CHANGETRIGGER', IPS_EVENTMESSAGE + 7);
+            define('EM_CHANGETRIGGERVALUE', IPS_EVENTMESSAGE + 8);
+            define('EM_CHANGETRIGGEREXECUTION', IPS_EVENTMESSAGE + 9);
+            define('EM_CHANGECYCLIC', IPS_EVENTMESSAGE + 10);
+            define('EM_CHANGECYCLICDATEFROM', IPS_EVENTMESSAGE + 11);
+            define('EM_CHANGECYCLICDATETO', IPS_EVENTMESSAGE + 12);
+            define('EM_CHANGECYCLICTIMEFROM', IPS_EVENTMESSAGE + 13);
+            define('EM_CHANGECYCLICTIMETO', IPS_EVENTMESSAGE + 14);
+
+            // --- MEDIA MANAGER
+            define('IPS_MEDIAMESSAGE', IPS_BASE + 900);           // Media Manager Message
+            define('MM_CREATE', IPS_MEDIAMESSAGE + 1);             // On Media Create
+            define('MM_DELETE', IPS_MEDIAMESSAGE + 2);             // On Media Delete
+            define('MM_CHANGEFILE', IPS_MEDIAMESSAGE + 3);         // On Media File changed
+            define('MM_AVAILABLE', IPS_MEDIAMESSAGE + 4);          // Media Available Status changed
+            define('MM_UPDATE', IPS_MEDIAMESSAGE + 5);
+
+            // --- LINK MANAGER
+            define('IPS_LINKMESSAGE', IPS_BASE + 1000);           // Link Manager Message
+            define('LM_CREATE', IPS_LINKMESSAGE + 1);             // On Link Create
+            define('LM_DELETE', IPS_LINKMESSAGE + 2);             // On Link Delete
+            define('LM_CHANGETARGET', IPS_LINKMESSAGE + 3);       // On Link TargetID change
+
+            // --- DATA HANDLER
+            define('IPS_DATAMESSAGE', IPS_BASE + 1100);            // Data Handler Message
+            define('FM_CONNECT', IPS_DATAMESSAGE + 1);             // On Instance Connect
+            define('FM_DISCONNECT', IPS_DATAMESSAGE + 2);          // On Instance Disconnect
+            define('FM_CHILDADDED', IPS_DATAMESSAGE + 3);          // On Child Instance Connect
+            define('FM_CHILDREMOVED', IPS_DATAMESSAGE + 4);        // On Child Instance Disconnect
+
+            // --- SCRIPT ENGINE
+            define('IPS_ENGINEMESSAGE', IPS_BASE + 1200);           // Script Engine Message
+            define('SE_UPDATE', IPS_ENGINEMESSAGE + 1);             // On Library Refresh
+            define('SE_EXECUTE', IPS_ENGINEMESSAGE + 2);            // On Script Finished execution
+            define('SE_RUNNING', IPS_ENGINEMESSAGE + 3);            // On Script Started execution
+
+            // --- PROFILE POOL
+            define('IPS_PROFILEMESSAGE', IPS_BASE + 1300);
+            define('PM_CREATE', IPS_PROFILEMESSAGE + 1);
+            define('PM_DELETE', IPS_PROFILEMESSAGE + 2);
+            define('PM_CHANGETEXT', IPS_PROFILEMESSAGE + 3);
+            define('PM_CHANGEVALUES', IPS_PROFILEMESSAGE + 4);
+            define('PM_CHANGEDIGITS', IPS_PROFILEMESSAGE + 5);
+            define('PM_CHANGEICON', IPS_PROFILEMESSAGE + 6);
+            define('PM_ASSOCIATIONADDED', IPS_PROFILEMESSAGE + 7);
+            define('PM_ASSOCIATIONREMOVED', IPS_PROFILEMESSAGE + 8);
+            define('PM_ASSOCIATIONCHANGED', IPS_PROFILEMESSAGE + 9);
+
+            // --- TIMER POOL
+            define('IPS_TIMERMESSAGE', IPS_BASE + 1400);            // Timer Pool Message
+            define('TM_REGISTER', IPS_TIMERMESSAGE + 1);
+            define('TM_UNREGISTER', IPS_TIMERMESSAGE + 2);
+            define('TM_SETINTERVAL', IPS_TIMERMESSAGE + 3);
+            define('TM_UPDATE', IPS_TIMERMESSAGE + 4);
+            define('TM_RUNNING', IPS_TIMERMESSAGE + 5);
+
+            // --- STATUS CODES
+            define('IS_SBASE', 100);
+            define('IS_CREATING', IS_SBASE + 1); // module is being created
+            define('IS_ACTIVE', IS_SBASE + 2); // module created and running
+            define('IS_DELETING', IS_SBASE + 3); // module us being deleted
+            define('IS_INACTIVE', IS_SBASE + 4); // module is not beeing used
+
+            // --- ERROR CODES
+            define('IS_EBASE', 200);          // default errorcode
+            define('IS_NOTCREATED', IS_EBASE + 1); // instance could not be created
+
+            // --- Search Handling
+            define('FOUND_UNKNOWN', 0);     // Undefined value
+            define('FOUND_NEW', 1);         // Device is new and not configured yet
+            define('FOUND_OLD', 2);         // Device is already configues (InstanceID should be set)
+            define('FOUND_CURRENT', 3);     // Device is already configues (InstanceID is from the current/searching Instance)
+            define('FOUND_UNSUPPORTED', 4); // Device is not supported by Module
+            define('vtBoolean', 0);
+            define('vtInteger', 1);
+            define('vtFloat', 2);
+            define('vtString', 3);
+            define('vtArray', 8);
+            define('vtObject', 9);
+        }
+    }
+}

--- a/libs/helpers/Traits/TableHelper.php
+++ b/libs/helpers/Traits/TableHelper.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Trait TableHelper
+ * convert data array to optimized html table
+ */
+trait TableHelper
+{
+    /**
+     * convert data array to html table
+     * @param array $data
+     * @return array
+     */
+    protected function convertDataTables($data = [])
+    {
+        foreach ($data AS &$values) {
+            if (isset($values['table'])) {
+                $prepend = isset($values['prepend']) ? $values['prepend'] : '';
+
+                // build table head
+                $html = <<<EOF
+                <style>
+                    .cktable th,
+                    .cktable td {
+                        padding: .5em .8em;
+                    }
+                    .cktable .th { text-align:left; white-space: nowrap; }
+                    .cktable tr.th:nth-child(odd) {background: rgba(0,0,0,0.4)}
+                    .cktable tr:nth-child(odd) {background: rgba(0,0,0,0.2)}
+                    .unicode,.unicode:link,.unicode:visited {border:0;background:transparent;padding:0;font-size:4em;cursor:pointer;color:#FFF;text-decoration:none}
+                    .unicode.play {font-size:2.5em;position:relative;top:-0.1em}
+                    .unicode.red {color:red}
+                    .separator { background: rgba(0,0,0,0.3);font-weight:bold;font-size:1.2em }
+                </style>
+                $prepend
+			<table class="cktable" cellpadding="0" cellspacing="0" width="100%">
+				<tr class="th">
+EOF;
+                foreach ($values['table']['head'] AS $th) {
+                    $options = '';
+                    if (is_array($th)) {
+                        $options = ' ' . $th[1];
+                        $th = $th[0];
+                    }
+
+                    $html .= '<th class="th"' . $options . '>' . $this->Translate($th) . '</th>';
+                }
+
+                $html .= '</tr>';
+
+                // build table body
+                foreach ($values['table']['body'] AS $tr) {
+                    $html .= '<tr>';
+                    foreach ($tr AS $td) {
+                        $options = '';
+                        if (is_array($td)) {
+                            $options = ' ' . $td[1];
+                            $td = $td[0];
+                        }
+
+                        $html .= '<td' . $options . '>' . $this->Translate($td) . '</td>';
+                    }
+
+                    $html .= '</tr>';
+                }
+
+                $html .= '</table>';
+
+                // replace value with html
+                $values = $html;
+            }
+        }
+
+        return $data;
+    }
+}

--- a/libs/helpers/autoload.php
+++ b/libs/helpers/autoload.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Class Autoloader
+ */
+spl_autoload_register(function ($className) {
+    // file
+    $file =  DIRECTORY_SEPARATOR . str_replace('\\', DIRECTORY_SEPARATOR, $className) . '.php';
+
+    // find in helpers dir
+    $helperDir = __DIR__;
+    if (file_exists($helperDir . $file)) {
+        require_once $helperDir . $file;
+    }
+
+    // find in traits dir
+    if (file_exists($helperDir . DIRECTORY_SEPARATOR . 'Traits' . $file)) {
+        require_once $helperDir . DIRECTORY_SEPARATOR . 'Traits' . $file;
+    }
+
+    // find in libs dir
+    $libsDir = dirname(__DIR__);
+    if (file_exists($libsDir . $file)) {
+        require_once $libsDir . $file;
+    }
+});

--- a/libs/helpers/ips.constants.php
+++ b/libs/helpers/ips.constants.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Set constants below IP-Symcon 5
+ */
+if (@constant('IPS_BASE') == null) {
+    // --- BASE MESSAGE
+    define('IPS_BASE', 10000);                             // Base Message
+    define('IPS_KERNELSHUTDOWN', IPS_BASE + 1);            // Pre Shutdown Message, Runlevel UNINIT Follows
+    define('IPS_KERNELSTARTED', IPS_BASE + 2);             // Post Ready Message
+
+    // --- KERNEL
+    define('IPS_KERNELMESSAGE', IPS_BASE + 100);           // Kernel Message
+    define('KR_CREATE', IPS_KERNELMESSAGE + 1);            // Kernel is beeing created
+    define('KR_INIT', IPS_KERNELMESSAGE + 2);              // Kernel Components are beeing initialised, Modules loaded, Settings read
+    define('KR_READY', IPS_KERNELMESSAGE + 3);             // Kernel is ready and running
+    define('KR_UNINIT', IPS_KERNELMESSAGE + 4);            // Got Shutdown Message, unloading all stuff
+    define('KR_SHUTDOWN', IPS_KERNELMESSAGE + 5);          // Uninit Complete, Destroying Kernel Inteface
+
+    // --- KERNEL LOGMESSAGE
+    define('IPS_LOGMESSAGE', IPS_BASE + 200);              // Logmessage Message
+    define('KL_MESSAGE', IPS_LOGMESSAGE + 1);              // Normal Message                      | FG: Black | BG: White  | STLYE : NONE
+    define('KL_SUCCESS', IPS_LOGMESSAGE + 2);              // Success Message                     | FG: Black | BG: Green  | STYLE : NONE
+    define('KL_NOTIFY', IPS_LOGMESSAGE + 3);               // Notiy about Changes                 | FG: Black | BG: Blue   | STLYE : NONE
+    define('KL_WARNING', IPS_LOGMESSAGE + 4);              // Warnings                            | FG: Black | BG: Yellow | STLYE : NONE
+    define('KL_ERROR', IPS_LOGMESSAGE + 5);                // Error Message                       | FG: Black | BG: Red    | STLYE : BOLD
+    define('KL_DEBUG', IPS_LOGMESSAGE + 6);                // Debug Informations + Script Results | FG: Grey  | BG: White  | STLYE : NONE
+    define('KL_CUSTOM', IPS_LOGMESSAGE + 7);               // User Message                        | FG: Black | BG: White  | STLYE : NONE
+
+    // --- MODULE LOADER
+    define('IPS_MODULEMESSAGE', IPS_BASE + 300);           // ModuleLoader Message
+    define('ML_LOAD', IPS_MODULEMESSAGE + 1);              // Module loaded
+    define('ML_UNLOAD', IPS_MODULEMESSAGE + 2);            // Module unloaded
+
+    // --- OBJECT MANAGER
+    define('IPS_OBJECTMESSAGE', IPS_BASE + 400);
+    define('OM_REGISTER', IPS_OBJECTMESSAGE + 1);          // Object was registered
+    define('OM_UNREGISTER', IPS_OBJECTMESSAGE + 2);        // Object was unregistered
+    define('OM_CHANGEPARENT', IPS_OBJECTMESSAGE + 3);      // Parent was Changed
+    define('OM_CHANGENAME', IPS_OBJECTMESSAGE + 4);        // Name was Changed
+    define('OM_CHANGEINFO', IPS_OBJECTMESSAGE + 5);        // Info was Changed
+    define('OM_CHANGETYPE', IPS_OBJECTMESSAGE + 6);        // Type was Changed
+    define('OM_CHANGESUMMARY', IPS_OBJECTMESSAGE + 7);     // Summary was Changed
+    define('OM_CHANGEPOSITION', IPS_OBJECTMESSAGE + 8);    // Position was Changed
+    define('OM_CHANGEREADONLY', IPS_OBJECTMESSAGE + 9);    // ReadOnly was Changed
+    define('OM_CHANGEHIDDEN', IPS_OBJECTMESSAGE + 10);     // Hidden was Changed
+    define('OM_CHANGEICON', IPS_OBJECTMESSAGE + 11);       // Icon was Changed
+    define('OM_CHILDADDED', IPS_OBJECTMESSAGE + 12);       // Child for Object was added
+    define('OM_CHILDREMOVED', IPS_OBJECTMESSAGE + 13);     // Child for Object was removed
+    define('OM_CHANGEIDENT', IPS_OBJECTMESSAGE + 14);      // Ident was Changed
+    define('OM_CHANGEDISABLED', IPS_OBJECTMESSAGE + 15);   // Operability has changed
+
+    // --- INSTANCE MANAGER
+    define('IPS_INSTANCEMESSAGE', IPS_BASE + 500);         // Instance Manager Message
+    define('IM_CREATE', IPS_INSTANCEMESSAGE + 1);          // Instance created
+    define('IM_DELETE', IPS_INSTANCEMESSAGE + 2);          // Instance deleted
+    define('IM_CONNECT', IPS_INSTANCEMESSAGE + 3);         // Instance connectged
+    define('IM_DISCONNECT', IPS_INSTANCEMESSAGE + 4);      // Instance disconncted
+    define('IM_CHANGESTATUS', IPS_INSTANCEMESSAGE + 5);    // Status was Changed
+    define('IM_CHANGESETTINGS', IPS_INSTANCEMESSAGE + 6);  // Settings were Changed
+    define('IM_CHANGESEARCH', IPS_INSTANCEMESSAGE + 7);    // Searching was started/stopped
+    define('IM_SEARCHUPDATE', IPS_INSTANCEMESSAGE + 8);    // Searching found new results
+    define('IM_SEARCHPROGRESS', IPS_INSTANCEMESSAGE + 9);  // Searching progress in %
+    define('IM_SEARCHCOMPLETE', IPS_INSTANCEMESSAGE + 10); // Searching is complete
+
+    // --- VARIABLE MANAGER
+    define('IPS_VARIABLEMESSAGE', IPS_BASE + 600);              // Variable Manager Message
+    define('VM_CREATE', IPS_VARIABLEMESSAGE + 1);               // Variable Created
+    define('VM_DELETE', IPS_VARIABLEMESSAGE + 2);               // Variable Deleted
+    define('VM_UPDATE', IPS_VARIABLEMESSAGE + 3);               // On Variable Update
+    define('VM_CHANGEPROFILENAME', IPS_VARIABLEMESSAGE + 4);    // On Profile Name Change
+    define('VM_CHANGEPROFILEACTION', IPS_VARIABLEMESSAGE + 5);  // On Profile Action Change
+
+    // --- SCRIPT MANAGER
+    define('IPS_SCRIPTMESSAGE', IPS_BASE + 700);           // Script Manager Message
+    define('SM_CREATE', IPS_SCRIPTMESSAGE + 1);            // On Script Create
+    define('SM_DELETE', IPS_SCRIPTMESSAGE + 2);            // On Script Delete
+    define('SM_CHANGEFILE', IPS_SCRIPTMESSAGE + 3);        // On Script File changed
+    define('SM_BROKEN', IPS_SCRIPTMESSAGE + 4);            // Script Broken Status changed
+
+    // --- EVENT MANAGER
+    define('IPS_EVENTMESSAGE', IPS_BASE + 800);             // Event Scripter Message
+    define('EM_CREATE', IPS_EVENTMESSAGE + 1);             // On Event Create
+    define('EM_DELETE', IPS_EVENTMESSAGE + 2);             // On Event Delete
+    define('EM_UPDATE', IPS_EVENTMESSAGE + 3);
+    define('EM_CHANGEACTIVE', IPS_EVENTMESSAGE + 4);
+    define('EM_CHANGELIMIT', IPS_EVENTMESSAGE + 5);
+    define('EM_CHANGESCRIPT', IPS_EVENTMESSAGE + 6);
+    define('EM_CHANGETRIGGER', IPS_EVENTMESSAGE + 7);
+    define('EM_CHANGETRIGGERVALUE', IPS_EVENTMESSAGE + 8);
+    define('EM_CHANGETRIGGEREXECUTION', IPS_EVENTMESSAGE + 9);
+    define('EM_CHANGECYCLIC', IPS_EVENTMESSAGE + 10);
+    define('EM_CHANGECYCLICDATEFROM', IPS_EVENTMESSAGE + 11);
+    define('EM_CHANGECYCLICDATETO', IPS_EVENTMESSAGE + 12);
+    define('EM_CHANGECYCLICTIMEFROM', IPS_EVENTMESSAGE + 13);
+    define('EM_CHANGECYCLICTIMETO', IPS_EVENTMESSAGE + 14);
+
+    // --- MEDIA MANAGER
+    define('IPS_MEDIAMESSAGE', IPS_BASE + 900);           // Media Manager Message
+    define('MM_CREATE', IPS_MEDIAMESSAGE + 1);             // On Media Create
+    define('MM_DELETE', IPS_MEDIAMESSAGE + 2);             // On Media Delete
+    define('MM_CHANGEFILE', IPS_MEDIAMESSAGE + 3);         // On Media File changed
+    define('MM_AVAILABLE', IPS_MEDIAMESSAGE + 4);          // Media Available Status changed
+    define('MM_UPDATE', IPS_MEDIAMESSAGE + 5);
+
+    // --- LINK MANAGER
+    define('IPS_LINKMESSAGE', IPS_BASE + 1000);           // Link Manager Message
+    define('LM_CREATE', IPS_LINKMESSAGE + 1);             // On Link Create
+    define('LM_DELETE', IPS_LINKMESSAGE + 2);             // On Link Delete
+    define('LM_CHANGETARGET', IPS_LINKMESSAGE + 3);       // On Link TargetID change
+
+    // --- DATA HANDLER
+    define('IPS_DATAMESSAGE', IPS_BASE + 1100);            // Data Handler Message
+    define('FM_CONNECT', IPS_DATAMESSAGE + 1);             // On Instance Connect
+    define('FM_DISCONNECT', IPS_DATAMESSAGE + 2);          // On Instance Disconnect
+    define('FM_CHILDADDED', IPS_DATAMESSAGE + 3);          // On Child Instance Connect
+    define('FM_CHILDREMOVED', IPS_DATAMESSAGE + 4);        // On Child Instance Disconnect
+
+    // --- SCRIPT ENGINE
+    define('IPS_ENGINEMESSAGE', IPS_BASE + 1200);           // Script Engine Message
+    define('SE_UPDATE', IPS_ENGINEMESSAGE + 1);             // On Library Refresh
+    define('SE_EXECUTE', IPS_ENGINEMESSAGE + 2);            // On Script Finished execution
+    define('SE_RUNNING', IPS_ENGINEMESSAGE + 3);            // On Script Started execution
+
+    // --- PROFILE POOL
+    define('IPS_PROFILEMESSAGE', IPS_BASE + 1300);
+    define('PM_CREATE', IPS_PROFILEMESSAGE + 1);
+    define('PM_DELETE', IPS_PROFILEMESSAGE + 2);
+    define('PM_CHANGETEXT', IPS_PROFILEMESSAGE + 3);
+    define('PM_CHANGEVALUES', IPS_PROFILEMESSAGE + 4);
+    define('PM_CHANGEDIGITS', IPS_PROFILEMESSAGE + 5);
+    define('PM_CHANGEICON', IPS_PROFILEMESSAGE + 6);
+    define('PM_ASSOCIATIONADDED', IPS_PROFILEMESSAGE + 7);
+    define('PM_ASSOCIATIONREMOVED', IPS_PROFILEMESSAGE + 8);
+    define('PM_ASSOCIATIONCHANGED', IPS_PROFILEMESSAGE + 9);
+
+    // --- TIMER POOL
+    define('IPS_TIMERMESSAGE', IPS_BASE + 1400);            // Timer Pool Message
+    define('TM_REGISTER', IPS_TIMERMESSAGE + 1);
+    define('TM_UNREGISTER', IPS_TIMERMESSAGE + 2);
+    define('TM_SETINTERVAL', IPS_TIMERMESSAGE + 3);
+    define('TM_UPDATE', IPS_TIMERMESSAGE + 4);
+    define('TM_RUNNING', IPS_TIMERMESSAGE + 5);
+
+    // --- STATUS CODES
+    define('IS_SBASE', 100);
+    define('IS_CREATING', IS_SBASE + 1); // module is being created
+    define('IS_ACTIVE', IS_SBASE + 2); // module created and running
+    define('IS_DELETING', IS_SBASE + 3); // module us being deleted
+    define('IS_INACTIVE', IS_SBASE + 4); // module is not beeing used
+
+    // --- ERROR CODES
+    define('IS_EBASE', 200);          // default errorcode
+    define('IS_NOTCREATED', IS_EBASE + 1); // instance could not be created
+
+    // --- Search Handling
+    define('FOUND_UNKNOWN', 0);     // Undefined value
+    define('FOUND_NEW', 1);         // Device is new and not configured yet
+    define('FOUND_OLD', 2);         // Device is already configues (InstanceID should be set)
+    define('FOUND_CURRENT', 3);     // Device is already configues (InstanceID is from the current/searching Instance)
+    define('FOUND_UNSUPPORTED', 4); // Device is not supported by Module
+    define('vtBoolean', 0);
+    define('vtInteger', 1);
+    define('vtFloat', 2);
+    define('vtString', 3);
+    define('vtArray', 8);
+    define('vtObject', 9);
+}

--- a/libs/helpers/update.helpers.sh
+++ b/libs/helpers/update.helpers.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# config
+DIR=$(cd `dirname $0` && pwd)
+REPO=$1
+
+if [ -z $REPO ]; then
+    REPO='HomeConnectSymcon*'
+fi
+
+# colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# prompt
+echo ""
+while true; do
+    read -p "Push to github after update? [y|n] " yn
+    case $yn in
+        [Yy]* ) PUSH=1; break;;
+        "") PUSH=1; break;;
+        [Nn]* ) PUSH=0; break;;
+        * ) echo "Please answer yes or no.";;
+    esac
+done
+
+# update git submodules
+echo ""
+find ../ -type d -iname "${REPO}" -print0 | while IFS= read -r -d $'\0' folder; do
+    project=$(echo $folder | cut -d'/' -f 2)
+    echo -e -n "${CYAN}updating${NC} ${BOLD}${project}${NC}... "
+
+    cd $folder
+    git submodule update --remote --force --quiet &> /dev/null
+
+    if [ $PUSH -eq 1 ]; then
+        git commit -a -m "helpers updated" &> /dev/null
+        git remote add origin https://github.com/hermanthegerman2/${project}.git &> /dev/null
+        git push -u origin master &> /dev/null
+    fi
+
+    echo -e "${GREEN}done!${NC}"
+    cd $DIR
+done
+


### PR DESCRIPTION
Wie versprochen hier nun der PR nachdem ich nochmal etwas aufgeräumt und getestet habe.
TLS läuft bei mir nun seit mehreren Wochen stabil.

Änderungen:
- TLS (optional) hinzugefügt
- optionales abschalten des automatischen # Subscribe
- Client kann sich nun als Version 3.1.1 kompatibel "ausgeben"
- Patch in phpMQTT eingefügt (Subscribe hatte falsches Format)
- Child Module können nun explizit subscriben
- Automatischer reconnect über Timer
- PHP Warnings (IPS Error) bei fehlerhaftem connect in IPS Warning umgesetzt
- Ping Intervall via Konfiguration einstellbar
- README erweitert

Ich nutze den MQTT Client nun als Parent für mein iRobot Roomba Modul im dev Branch welches jedoch noch Beta ist [SymconRoomba](https://github.com/danielrdt/SymconRoomba) - läuft mit dem Modul deutlich stabiler!