### PR TITLE
Strict Types erzeugen im TLS Buffer eine Exception

### DIFF
--- a/libs/TLS/PTLS/Buffer.php
+++ b/libs/TLS/PTLS/Buffer.php
@@ -37,6 +37,7 @@ class Buffer
 
     public function length()
     {
+        if(!$this->buffer) return 0;
         return strlen($this->buffer);
     }
 }

--- a/libs/TLS/PTLS/Buffer.php
+++ b/libs/TLS/PTLS/Buffer.php
@@ -37,7 +37,9 @@ class Buffer
 
     public function length()
     {
-        if (!$this->buffer) return 0;
+        if (!$this->buffer) {
+            return 0;
+        }
         return strlen($this->buffer);
     }
 }

--- a/libs/TLS/PTLS/Buffer.php
+++ b/libs/TLS/PTLS/Buffer.php
@@ -37,7 +37,7 @@ class Buffer
 
     public function length()
     {
-        if(!$this->buffer) return 0;
+        if (!$this->buffer) return 0;
         return strlen($this->buffer);
     }
 }

--- a/libs/TLS/PTLS/ConnectionDuplex.php
+++ b/libs/TLS/PTLS/ConnectionDuplex.php
@@ -88,7 +88,7 @@ class ConnectionDuplex
             $record->encode($data);
             $data = $record->get('dataRest');
 
-            if ($strlen == strlen($data)) {
+            if (!is_null($data) && $strlen == strlen($data)) {
                 throw new TLSAlertException(Alert::create(Alert::INTERNAL_ERROR), 'Failed on encodeRecord');
             }
         }


### PR DESCRIPTION
Mit der aktuellen Version kann bei mir keine TLS Verbindung mehr hergestellt werden.

Nach Prüfung konnte ich das Problem auf die hinzugefügte strict_types Definition zurück führen. Beim Verbindungsaufbau wird an einer Stelle die Länge des Buffers geprüft. An dieser Stelle ist er aber null.
Ohne strict_types gab strlen hier 0 zurück - mit strict_types kommt es zu einer Exception.

Habe das Problem mit einer vorgelagerten Prüfung  auf alle Arten von null behoben.