### PR TITLE
fehlender MQTT-mesage-code 0x9 (SUBACK) ergänzt

### DIFF
--- a/libs/TFphpMQTT.php
+++ b/libs/TFphpMQTT.php
@@ -264,6 +264,12 @@ class phpMQTT
                     case 3: // PUBLISH, Publish message
                                 $this->message($string);
                         break;
+                    case 9:         // SUBACK
+                        if ($this->debug) {
+                            $call = $this->onDebug;
+                            $this->owner->$call('MQTT:RX::SUBACK', '');
+                        }
+                        break;
                     case 13:         // PINGRESP, PING response
                         if ($this->debug) {
                             $call = $this->onDebug;


### PR DESCRIPTION
Ich bekommen diese Nachricht immer aufgrund eines subscribe(), soweit ich das beobachtet habe, reicht dieser Fix aus

demel