### PR TITLE
Es ist nicht möglich den Client Socket zu deaktivieren

### DIFF
--- a/MQTTClient/module.php
+++ b/MQTTClient/module.php
@@ -173,10 +173,10 @@ class MQTTClient extends IPSModule
         $cID = $this->GetConnectionID();
         if (($this->HasActiveParent() || $force) && $cID > 0) {
             set_error_handler([$this, 'onConnectError']);
-            if (IPS_SetProperty($cID, 'Open', true)) {
+/*            if (IPS_SetProperty($cID, 'Open', true)) {
                 IPS_ApplyChanges($cID);
             }
-            restore_error_handler();
+*/            restore_error_handler();
         }
     }
 


### PR DESCRIPTION
Client Socket wird permanent wieder aktiviert, auch wenn man diesen explizit manuell deaktiviert hat.
Ist der Client Socket deaktiviert, wird dies sehr deutlich in der MQTT Client Instanz angezeigt, so dass dieser schlechte Implementierungsstil hier definitiv nicht nötig ist.